### PR TITLE
Use default values to simplify common boss configuration 

### DIFF
--- a/boss/api/deployment/preset/node.py
+++ b/boss/api/deployment/preset/node.py
@@ -17,12 +17,6 @@ from boss.api import shell, notif, runner, fs, git
 from boss.config import get as get_config
 from .. import buildman
 
-# Default files deployed along with the build for the nodejs project.
-NODE_INCLUDE_FILES = [
-    'package.json',
-    'package-lock.json', 'yarn.lock', 'pm2.config.js'
-]
-
 
 @task
 def builds():
@@ -80,9 +74,7 @@ def deploy():
 
     tmp_path = fs.get_temp_filename()
     build_dir = config['deployment']['build_dir']
-    included_files = (
-        config['deployment']['include_files'] or NODE_INCLUDE_FILES
-    )
+    included_files = config['deployment']['include_files']
 
     deployer_user = shell.get_user()
 

--- a/boss/api/deployment/preset/node.py
+++ b/boss/api/deployment/preset/node.py
@@ -73,7 +73,7 @@ def deploy():
     ))
 
     tmp_path = fs.get_temp_filename()
-    build_dir = config['deployment']['build_dir']
+    build_dir = buildman.resolve_local_build_dir()
     included_files = config['deployment']['include_files']
 
     deployer_user = shell.get_user()

--- a/boss/api/deployment/preset/node.py
+++ b/boss/api/deployment/preset/node.py
@@ -17,7 +17,11 @@ from boss.api import shell, notif, runner, fs, git
 from boss.config import get as get_config
 from .. import buildman
 
-NODE_INCLUDE_FILES = ['package.json', 'yarn.lock', 'package-lock.json']
+# Default files deployed along with the build for the nodejs project.
+NODE_INCLUDE_FILES = [
+    'package.json',
+    'package-lock.json', 'yarn.lock', 'pm2.config.js'
+]
 
 
 @task

--- a/boss/api/deployment/preset/web.py
+++ b/boss/api/deployment/preset/web.py
@@ -47,7 +47,6 @@ def setup():
 @task
 def deploy():
     ''' Zero-Downtime deployment for the web. '''
-    config = get_config()
     stage = shell.get_stage()
     user = get_stage_config(stage)['user']
 
@@ -61,7 +60,7 @@ def deploy():
     ))
 
     tmp_path = fs.get_temp_filename()
-    build_dir = config['deployment']['build_dir']
+    build_dir = buildman.resolve_local_build_dir()
 
     deploy_dir = buildman.get_deploy_dir()
     deployer_user = shell.get_user()

--- a/boss/config.py
+++ b/boss/config.py
@@ -6,7 +6,7 @@ from copy import deepcopy
 import yaml
 import dotenv
 from .util import halt, merge
-from .constants import DEFAULT_CONFIG, DEFAULT_CONFIG_FILE
+from .constants import DEFAULT_CONFIG, DEFAULT_CONFIG_FILE, PRESET_SPECIFIC_DEFAULTS
 _config = deepcopy(DEFAULT_CONFIG)
 
 
@@ -47,7 +47,15 @@ def load(filename=DEFAULT_CONFIG_FILE, stage=None):
 
             # Parse the yaml configuration.
             loaded_config = yaml.load(loaded_config)
-            merged_config = merge(DEFAULT_CONFIG, loaded_config)
+
+            # Merge the default config along with preset specific defaults
+            # to the loaded config.
+            preset = loaded_config['deployment'].get('preset') or DEFAULT_CONFIG[
+                'deployment']['preset']
+            preset_defaults = PRESET_SPECIFIC_DEFAULTS[preset]
+            all_defaults = merge(DEFAULT_CONFIG, preset_defaults)
+            merged_config = merge(all_defaults, loaded_config)
+
             _config.update(merged_config)
 
             # Add base config to each of the stage config

--- a/boss/constants.py
+++ b/boss/constants.py
@@ -59,3 +59,23 @@ SCRIPT_STATUS_CHECK = 'status_check'
 SCRIPT_LIST_SERVICES = 'list_services'
 SCRIPT_INSTALL_REMOTE = 'install_remote'
 SCRIPT_START_OR_RELOAD = 'start_or_reload'
+
+
+# Preset specific defaults
+PRESET_SPECIFIC_DEFAULTS = {
+    PRESET_REMOTE_SOURCE: {},
+    PRESET_WEB: {},
+    PRESET_NODE: {
+        'deployment': {
+            'include_files': [
+                'package.json', 'package-lock.json', 'yarn.lock', 'pm2.config.js'
+            ]
+        },
+        'scripts': {
+            SCRIPT_INSTALL: 'npm install',
+            SCRIPT_INSTALL_REMOTE: 'npm install',
+            SCRIPT_BUILD: 'npm run build'
+            # TODO: Add pm2 based scripts too as a default.
+        }
+    }
+}

--- a/boss/constants.py
+++ b/boss/constants.py
@@ -23,7 +23,7 @@ DEFAULT_CONFIG = {
     'scripts': {},
     'deployment': {
         'preset': PRESET_REMOTE_SOURCE,
-        'build_dir': 'build/',
+        'build_dir': None,
         'base_dir': '~/boss',
         'keep_builds': 5,
         'include_files': []

--- a/boss/constants.py
+++ b/boss/constants.py
@@ -25,7 +25,7 @@ DEFAULT_CONFIG = {
         'preset': PRESET_REMOTE_SOURCE,
         'build_dir': 'build/',
         'base_dir': '~/boss',
-        'keep_builds': 3,
+        'keep_builds': 5,
         'include_files': []
     },
     'notifications': {


### PR DESCRIPTION
 * Fallback to common build directories locally eg: `build/`, `dist/` if `build_dir` config option is not provided
 * Set default `build_dir` as `None` in the config.
 * Make use of preset specific defaults for `node` preset eg: `npm install`, `npm run build` for `install` and `build` scripts.
 * Add `pm2.config.js` to default included files for `node` preset
 * Set default `keep_builds` to `5`.