### PR TITLE
Simplify deploying output with a shorter message

### DIFF
--- a/boss/api/deployment/preset/node.py
+++ b/boss/api/deployment/preset/node.py
@@ -9,7 +9,7 @@ is started on restarted on the remote server.
 
 from datetime import datetime
 
-from fabric.colors import cyan
+from fabric.colors import cyan, green
 from fabric.api import task, cd, shell_env
 
 from boss import constants
@@ -67,13 +67,13 @@ def deploy():
     stage = shell.get_stage()
     is_first_deployment = not buildman.is_remote_setup()
 
-    info('Deploying app to the {} server'.format(stage))
-    # Get the current branch and commit (locally).
     branch = git.current_branch(remote=False)
-    commit = git.last_commit(remote=False)
-
-    echo('  Branch: {}'.format(cyan(branch)))
-    echo('  Commit: {}'.format(cyan(commit)))
+    commit = git.last_commit(remote=False, short=True)
+    info('Deploying <{branch}:{commit}> to the {stage} server'.format(
+        branch=branch,
+        commit=commit,
+        stage=stage
+    ))
 
     tmp_path = fs.get_temp_filename()
     build_dir = config['deployment']['build_dir']

--- a/boss/api/deployment/preset/node.py
+++ b/boss/api/deployment/preset/node.py
@@ -9,11 +9,10 @@ is started on restarted on the remote server.
 
 from datetime import datetime
 
-from fabric.colors import cyan, green
 from fabric.api import task, cd, shell_env
 
 from boss import constants
-from boss.util import info, remote_info, echo, halt
+from boss.util import info, remote_info, halt
 from boss.api import shell, notif, runner, fs, git
 from boss.config import get as get_config
 from .. import buildman

--- a/boss/api/deployment/preset/web.py
+++ b/boss/api/deployment/preset/web.py
@@ -52,13 +52,14 @@ def deploy():
     stage = shell.get_stage()
     user = get_stage_config(stage)['user']
 
-    info('Deploying app to the {} server'.format(stage))
     # Get the current branch and commit (locally).
     branch = git.current_branch(remote=False)
-    commit = git.last_commit(remote=False)
-
-    echo('  Branch: {}'.format(cyan(branch)))
-    echo('  Commit: {}'.format(cyan(commit)))
+    commit = git.last_commit(remote=False, short=True)
+    info('Deploying <{branch}:{commit}> to the {stage} server'.format(
+        branch=branch,
+        commit=commit,
+        stage=stage
+    ))
 
     tmp_path = fs.get_temp_filename()
     build_dir = config['deployment']['build_dir']

--- a/boss/api/deployment/preset/web.py
+++ b/boss/api/deployment/preset/web.py
@@ -9,11 +9,10 @@ The source code is built locally and only the dist is uploaded and deployed to t
 
 from datetime import datetime
 
-from fabric.colors import cyan
 from fabric.api import task, cd, shell_env
 
 from boss import constants
-from boss.util import info, remote_info, echo
+from boss.util import info, remote_info
 from boss.api import shell, notif, runner, fs, git
 from boss.config import get as get_config, get_stage_config
 from .. import buildman

--- a/boss/api/git.py
+++ b/boss/api/git.py
@@ -24,7 +24,7 @@ def sync(branch):
     # TODO: Custom origin
 
 
-def last_commit(remote=True):
+def last_commit(remote=True, short=False):
     '''
     Get the last commit of the git repository.
 
@@ -32,7 +32,7 @@ def last_commit(remote=True):
     to be a git repository. So, make sure current directory is set before using this.
     '''
 
-    cmd = 'git rev-parse HEAD'
+    cmd = 'git rev-parse{}HEAD'.format(' --short ' if short else ' ')
 
     with hide('everything'):
         result = run(cmd) if remote else local(cmd, capture=True)


### PR DESCRIPTION
* Simplify deploying console output with a compact message.
  Previously, the message would be printed as this for deployment:
  ```
   Deploying app to the dev server
     Branch: dev
     Commit: f92ecdc17d845672e1dbda9e4e45bfa27d45eeaa
  ```

  Now, it's printed as this:
  ```
  Deploying <dev:f92ecdc> to the dev server
  ```
* Add `short` boolean flag on `git.last_commit()` function
