### PR TITLE
Simplify slack deployment message format

### DIFF
--- a/boss/api/hipchat.py
+++ b/boss/api/hipchat.py
@@ -6,7 +6,7 @@ import requests
 from ..config import get as _get_config
 
 DEPLOYING_MESSAGE = '{user} is deploying {project_link}:{branch_link} to {server_link} server.'
-DEPLOYED_SUCCESS_MESSAGE = 'Finished deploying {project_link}:{branch_link} to {server_link} server.'
+DEPLOYED_SUCCESS_MESSAGE = '{user} finished deploying {project_link}:{branch_link} to {server_link} server.'
 
 
 def config():

--- a/boss/api/hipchat.py
+++ b/boss/api/hipchat.py
@@ -82,6 +82,7 @@ def notify_deployed(**params):
     )
 
     text = DEPLOYED_SUCCESS_MESSAGE.format(
+        user=params['user'],
         branch_link=branch_link,
         project_link=project_link,
         server_link=server_short_link

--- a/boss/api/notif.py
+++ b/boss/api/notif.py
@@ -2,8 +2,6 @@
 Notification API module.
 '''
 
-from fabric.colors import cyan
-
 from . import slack
 from . import hipchat
 from ..util import remote_info

--- a/boss/api/slack.py
+++ b/boss/api/slack.py
@@ -55,23 +55,10 @@ def notify_deploying(**params):
     )
 
     payload = {
-        'text': text,
         'attachments': [
             {
-                'title': 'Deploying',
                 'color': config()['deploying_color'],
-                'fields': [
-                    {
-                        'title': 'Branch',
-                        'value': branch_link,
-                        'short': True
-                    },
-                    {
-                        'title': 'To',
-                        'value': server_link,
-                        'short': True
-                    }
-                ]
+                'text': text
             }
         ]
     }
@@ -100,23 +87,10 @@ def notify_deployed(**params):
     )
 
     payload = {
-        'text': text,
         'attachments': [
             {
-                'title': 'Finished Deploying',
                 'color': config()['deployed_color'],
-                'fields': [
-                    {
-                        'title': 'Branch',
-                        'value': branch_link,
-                        'short': True
-                    },
-                    {
-                        'title': 'To',
-                        'value': server_link,
-                        'short': True
-                    }
-                ]
+                'text': text
             }
         ]
     }

--- a/boss/api/slack.py
+++ b/boss/api/slack.py
@@ -7,7 +7,7 @@ import requests
 from ..config import get as _get_config
 
 DEPLOYING_MESSAGE = '{user} is deploying {project_link}:{branch_link} to {server_link} server.'
-DEPLOYED_SUCCESS_MESSAGE = 'Finished deploying {project_link}:{branch_link} to {server_link} server.'
+DEPLOYED_SUCCESS_MESSAGE = '{user} finished deploying {project_link}:{branch_link} to {server_link} server.'
 
 
 def config():

--- a/boss/api/slack.py
+++ b/boss/api/slack.py
@@ -81,6 +81,7 @@ def notify_deployed(**params):
     )
 
     text = DEPLOYED_SUCCESS_MESSAGE.format(
+        user=params['user'],
         branch_link=branch_link,
         project_link=project_link,
         server_link=server_short_link

--- a/tests/api/test_slack.py
+++ b/tests/api/test_slack.py
@@ -32,26 +32,14 @@ def test_notity_deploying():
         repository_url='http://repository-url',
         project_name='project-name',
         server_name='server-name',
+        server_link='http://server-link',
         user='user',
     )
     payload = {
-        "text": "user is deploying <http://repository-url|project-name>:<http://branch-url|test_notify_deploying> to <http://public-url|server-name> server.",
         "attachments": [
             {
                 "color": "good",
-                "fields": [
-                    {
-                        "short": True,
-                        "value": "<http://branch-url|test_notify_deploying>",
-                        "title": "Branch"
-                    },
-                    {
-                        "short": True,
-                        "value": "<http://public-url|test-notify-deploying-host>",
-                        "title": "To"
-                    }
-                ],
-                "title": "Deploying"
+                "text": "user is deploying <http://repository-url|project-name>:<http://branch-url|test_notify_deploying> to <http://public-url|server-name> server."
             }
         ]
     }
@@ -71,31 +59,19 @@ def test_notity_deployed():
         repository_url='http://repository-url',
         project_name='project-name',
         server_name='server-name',
-        user='user',
+        server_link='http://server-link',
+        user='user'
     )
     payload = {
-        "text": "user is deploying <http://repository-url|project-name>:<http://branch-url|test_notify_deployed> to <http://public-url|server-name> server.",
         "attachments": [
             {
-                "color": "good",
-                "fields": [
-                    {
-                        "short": True,
-                        "value": "<http://branch-url|test_notify_deployed>",
-                        "title": "Branch"
-                    },
-                    {
-                        "short": True,
-                        "value": "<http://public-url|test-notify-deployed-host>",
-                        "title": "To"
-                    }
-                ],
-                "title": "Deploying"
+                "color": "#764FA5",
+                "text": "user finished deploying <http://repository-url|project-name>:<http://branch-url|test_notify_deployed> to <http://public-url|server-name> server."
             }
         ]
     }
     base_url = slack.config()['base_url'] + slack.config()['endpoint']
 
     with patch('requests.post') as mock_post:
-        slack.notify_deploying(**notify_params)
+        slack.notify_deployed(**notify_params)
         mock_post.assert_called_once_with(base_url, json=payload)


### PR DESCRIPTION
* Add username to finished deploying message
 * Change slack message format
* Update tests

The new message format for Slack will look like [this](https://api.slack.com/docs/messages/builder?msg=%7B%22attachments%22%3A%5B%7B%22color%22%3A%22good%22%2C%22text%22%3A%22saugat%20finished%20deploying%20%20backbone-forum-api%3Adev%20to%20dev%20to%20server.%22%7D%5D%7D).