### PR TITLE
Add unit tests for some boss.util modules and some other minor fixes

### DIFF
--- a/boss/util.py
+++ b/boss/util.py
@@ -71,7 +71,10 @@ def is_string(obj):
 
 def is_iterable(obj):
     ''' Check if the object is iterable. '''
-    return hasattr(obj, '__iter__')
+    has_iter = hasattr(obj, '__iter__')
+    has_get_item = hasattr(obj, '__getitem__')
+
+    return has_iter or has_get_item
 
 
 def merge(dict1, dict2):

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,3 +3,4 @@ pytest-cov==2.5.1
 coverage==4.4.1
 mock==2.0.0
 pylint==1.7.4
+python-dotenv==0.6.5

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ setup(
         'click==6.7'
     ],
     extras_require={
-        'test': ['coverage', 'pytest', 'pytest-cov', 'pylint'],
+        'test': ['mock', 'coverage', 'pytest', 'pytest-cov', 'pylint'],
     },
     entry_points={
         'console_scripts': [

--- a/t
+++ b/t
@@ -23,7 +23,7 @@ publish() {
 
 test() {
   echo "Running tests"
-  python -m pytest
+  python -m pytest -s
 }
 
 testw() {
@@ -31,7 +31,7 @@ testw() {
   # Install it with `npm install -g chokidar-cli if you haven't.
   # https://github.com/kimmobrunfeldt/chokidar-cli
   echo "Running tests (watch mode)"
-  chokidar "**/*.py" --debounce=1000 --initial -c "python -m pytest"
+  chokidar "**/*.py" --debounce=1000 --initial -c "python -m pytest -s"
 }
 
 changelog() {

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,0 +1,125 @@
+''' Unit tests for boss.util module. '''
+
+import pytest
+
+from boss.util import (
+    halt,
+    info,
+    echo,
+    merge,
+    is_iterable
+)
+
+def test_halt():
+    ''' Test for boss.util.halt() '''
+    message = 'Test message'
+
+    with pytest.raises(SystemExit, match=message):
+        halt(message)
+
+def test_echo(capsys):
+    ''' Test for boss.util.echo() '''
+    message = 'Test message'
+    echo(message)
+
+    out, _ = capsys.readouterr()
+
+    assert message in out
+
+def test_info(capsys):
+    ''' Test for boss.util.info() '''
+    message = 'Test message'
+    info(message)
+
+    out, _ = capsys.readouterr()
+
+    assert message in out
+
+def test_merge_v0():
+    '''
+    Test for boss.util.merge()
+    Assert expected merge outcome when no conflicting keys are present.
+    '''
+    dict1 = {
+        'key1': 'value1',
+        'key2': {
+            'key3': 'value3',
+            'key4': 'value4'
+        }
+    }
+
+    dict2 = {
+        'keyA': 'valueA',
+        'key2': {
+            'keyB': 'valueB'
+        }
+    }
+
+    expectedmerge = {
+        'key1': 'value1',
+        'key2': {
+            'keyB': 'valueB',
+            'key3': 'value3',
+            'key4': 'value4'
+        },
+        'keyA': 'valueA'
+    }
+
+    merged = merge(dict1, dict2)
+
+    assert merged == expectedmerge
+
+def test_merge_v1():
+    '''
+    Test for boss.util.merge()
+    Assert that second dictionary overrides conflicting keys during merge
+    '''
+    dict1 = {
+        'key1': 'value1',
+        'key2': {
+            'key3': 'value3',
+            'key4': 'value4'
+        }
+    }
+
+    dict2 = {
+        'key1': 'valueA',
+        'key2': {
+            'keyB': 'valueB'
+        }
+    }
+
+    expectedmerge = {
+        'key1': 'valueA',
+        'key2': {
+            'keyB': 'valueB',
+            'key3': 'value3',
+            'key4': 'value4'
+        },
+    }
+
+    merged = merge(dict1, dict2)
+
+    assert merged == expectedmerge
+
+def test_is_iterable_v0():
+    ''' Test for boss.util.is_iterable() '''
+    def noop():
+        pass
+
+    assert is_iterable([]) is True
+    assert is_iterable({}) is True
+    assert is_iterable('random string') is True
+
+    assert is_iterable(noop) is False
+    assert is_iterable(None) is False
+
+
+def test_is_iterable_v1():
+    '''
+    Test for boss.util.is_iterable()
+    Any construct that adheres to the iterator protocol should return True
+    '''
+    gen = (n for n in xrange(0, 10))
+
+    assert is_iterable(gen) is True


### PR DESCRIPTION
* Partially fixes #64
* Added simple unit tests for `boss.util` modules that don't require mocking `fabric` functions.
* Since capturing `stdout` (and possibly `stderr` in the future) became necessary, added a `-s` flag to `pytest` scripts

## Changes to existing code:
  * Improved `is_iterable` function in `boss.util` to also check for `__getitem__` as well as `__iter__` since supporters of the sequence protocol also count as iterators. More info in the [docs](https://docs.python.org/2/library/functions.html#iter). (This almost certainly won't induce anything to break)
  * Added a few missing dependencies to `requirements-dev.txt` and `setup.py`

