### PR TITLE
Support for '--interactive' option for 'boss init'

### DIFF
--- a/boss/cli.py
+++ b/boss/cli.py
@@ -3,6 +3,7 @@ import click
 
 from .core import initializer
 
+INTERACTIVE_INIT_HELP = 'Start an interactive session to compose config file'
 
 @click.version_option(__version__, message='%(version)s')
 @click.group()
@@ -12,9 +13,10 @@ def main():
 
 
 @main.command('init')
-def init():
+@click.option('--interactive', '-i', is_flag=True, help=INTERACTIVE_INIT_HELP)
+def init(interactive):
     ''' Initialize a project directory for boss. '''
-    files_written = initializer.initialize()
+    files_written = initializer.initialize(interactive)
 
     if not files_written:
         click.echo('Already initialized.')

--- a/boss/core/initializer.py
+++ b/boss/core/initializer.py
@@ -7,29 +7,64 @@ from boss import BASE_PATH
 from boss.core import fs
 from boss.constants import DEFAULT_CONFIG, DEFAULT_CONFIG_FILE, FABFILE_PATH
 
+from boss.core.inquiries import get_initial_config_params
 
-def initialize():
+def initialize(interactive):
     ''' Initialize the local project directory for boss. '''
     files_written = []
-    fabfile = FABFILE_PATH
-    config_file = DEFAULT_CONFIG_FILE
 
-    # If config file doesn't exist create it.
-    if not fs.exists(config_file):
-        config_tmpl = fs.read(BASE_PATH + '/misc/boss.yml_template')
-        config_tmpl = config_tmpl.format(
-            project_name=DEFAULT_CONFIG['project_name'],
-            user=DEFAULT_CONFIG['user'],
-            deployment_preset=DEFAULT_CONFIG['deployment']['preset'],
-            deployment_base_dir=DEFAULT_CONFIG['deployment']['base_dir']
-        )
-        fs.write(config_file, config_tmpl)
+    # Initialize fabfile first. If it already exists, a None is returned
+    fabfile = initialize_fabfile()
+
+    if fabfile:
+        files_written.append(fabfile)
+
+    # Initialize boss.yml next. If it already exists, a None is returned
+    config_file = initialize_config(interactive)
+
+    if config_file:
         files_written.append(config_file)
 
-    # If fabfile doesn't exist create it.
+    return files_written
+
+
+def initialize_config(interactive):
+    '''
+    Initialize a new boss.yml file.
+    If the file already exists return None, else return the file.
+    '''
+    config_file = DEFAULT_CONFIG_FILE
+
+    # If config already exists, return None
+    if fs.exists(config_file):
+        return None
+
+    config_tmpl = fs.read(BASE_PATH + '/misc/boss.yml_template')
+
+    if not interactive:
+        tmpl_params = {
+            'project_name': DEFAULT_CONFIG['project_name'],
+            'user': DEFAULT_CONFIG['user'],
+            'deployment_preset': DEFAULT_CONFIG['deployment']['preset'],
+            'deployment_base_dir': DEFAULT_CONFIG['deployment']['base_dir']
+        }
+    else:
+        tmpl_params = get_initial_config_params()
+
+    fs.write(config_file, config_tmpl.format(**tmpl_params))
+
+    return config_file
+
+
+def initialize_fabfile():
+    '''
+    Initialize a new fabfile.
+    If the file already exists return None, else return the file.
+    '''
+    fabfile = FABFILE_PATH
+
     if not fs.exists(fabfile):
         fabfile_tmpl = fs.read(BASE_PATH + '/misc/fabfile.py_template')
         fs.write(fabfile, fabfile_tmpl)
-        files_written.append(fabfile)
 
-    return files_written
+        return fabfile

--- a/boss/core/initializer.py
+++ b/boss/core/initializer.py
@@ -45,7 +45,7 @@ def initialize_config(interactive):
         tmpl_params = {
             'project_name': DEFAULT_CONFIG['project_name'],
             'user': DEFAULT_CONFIG['user'],
-            'port': DEFAULT_CONFIG['port'],
+            'ssh_port': DEFAULT_CONFIG['port'],
             'deployment_preset': DEFAULT_CONFIG['deployment']['preset'],
             'deployment_base_dir': DEFAULT_CONFIG['deployment']['base_dir']
         }

--- a/boss/core/initializer.py
+++ b/boss/core/initializer.py
@@ -45,6 +45,7 @@ def initialize_config(interactive):
         tmpl_params = {
             'project_name': DEFAULT_CONFIG['project_name'],
             'user': DEFAULT_CONFIG['user'],
+            'port': DEFAULT_CONFIG['port'],
             'deployment_preset': DEFAULT_CONFIG['deployment']['preset'],
             'deployment_base_dir': DEFAULT_CONFIG['deployment']['base_dir']
         }

--- a/boss/core/inquiries.py
+++ b/boss/core/inquiries.py
@@ -1,0 +1,38 @@
+'''
+A module to handle interaction of the CLI with the user.
+'''
+from inquirer import Text, List, prompt
+
+from boss.constants import DEFAULT_CONFIG, PRESET_NODE, PRESET_REMOTE_SOURCE, PRESET_WEB
+
+def get_initial_config_params():
+    ''' Get initial config params from user. '''
+
+    questions = [
+        Text(
+            'project_name',
+            message='Enter your project_name',
+        ),
+
+        Text(
+            'user',
+            message='Enter your username',
+            default=DEFAULT_CONFIG['user']
+        ),
+
+        List(
+            'deployment_preset',
+            message='Select your deployment preset',
+            choices=[PRESET_WEB, PRESET_NODE, PRESET_REMOTE_SOURCE]
+            ),
+
+        Text(
+            'deployment_base_dir',
+            message="Enter your base directory for deployment",
+            default=DEFAULT_CONFIG['deployment']['base_dir']
+            )
+    ]
+
+    answers = prompt(questions)
+
+    return answers

--- a/boss/core/inquiries.py
+++ b/boss/core/inquiries.py
@@ -16,9 +16,15 @@ def get_initial_config_params():
 
         Text(
             'user',
-            message='Enter your username',
+            message='Enter your SSH username',
             default=DEFAULT_CONFIG['user']
         ),
+
+        Text(
+            'ssh_port',
+            message='Enter SSH port',
+            default=DEFAULT_CONFIG['port']
+            ),
 
         List(
             'deployment_preset',
@@ -28,7 +34,7 @@ def get_initial_config_params():
 
         Text(
             'deployment_base_dir',
-            message="Enter your base directory for deployment",
+            message='Enter your base directory for deployment',
             default=DEFAULT_CONFIG['deployment']['base_dir']
             )
     ]

--- a/boss/misc/boss.yml_template
+++ b/boss/misc/boss.yml_template
@@ -1,5 +1,6 @@
 project_name: {project_name}
 user: {user}
+port: {ssh_port}
 deployment:
     preset: {deployment_preset}
     base_dir: {deployment_base_dir}

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,3 +5,4 @@ mock==2.0.0
 pylint==1.7.4
 python-dotenv==0.6.5
 autopep8==1.3.3
+inquirer==2.2.0

--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,7 @@ setup(
         'fabric==1.13.2',
         'pyyaml==3.12',
         'requests==2.17.3',
+        'inquirer==2.2.0',
         'python-dotenv==0.6.5',
         'terminaltables==3.1.0',
         'click==6.7'

--- a/tests/core/test_initializer.py
+++ b/tests/core/test_initializer.py
@@ -7,8 +7,9 @@ from boss.core import initializer
 @patch('boss.core.fs.exists')
 def test_initialize_if_all_files_already_exist(mock_exists):
     ''' Test initializer.initialize() works if all the files exist already. '''
+    interactive_flag = False
     mock_exists.return_value = True
-    files_written = initializer.initialize()
+    files_written = initializer.initialize(interactive_flag)
 
     assert not files_written
 
@@ -17,7 +18,8 @@ def test_initialize_if_all_files_already_exist(mock_exists):
 @patch('boss.core.fs.exists')
 def test_initialize_if_no_files_exist(mock_exists, mock_write):
     ''' Test initializer.initilize() works if none of the files exist. '''
+    interactive_flag = False
     mock_exists.return_value = False
-    files_written = initializer.initialize()
+    files_written = initializer.initialize(interactive_flag)
 
     assert len(files_written) == mock_write.call_count


### PR DESCRIPTION
Deals with #74.

# Changes:
* Added Inquirer package 
* Created `inquiries.py` in `boss/core` to handle user interactions for the CLI
* Minor refactors to `initializer.py` to allow for clean handling of interactive flag

![boss-interactive](https://user-images.githubusercontent.com/24712573/32385543-a74bedde-c0e6-11e7-98b7-006ffbc5b07b.gif)

I've left out validation for any of the fields that we get from the user. What do I need to add?

Open to suggestions about messages and anything else. 😄 

EDIT: Added a better GIF.