### PR TITLE
Fix the misleading resolving env file message

### DIFF
--- a/boss/config.py
+++ b/boss/config.py
@@ -35,7 +35,7 @@ def resolve_dotenv_file(path, stage=None):
         dotenv.load_dotenv(dotenv_path)
 
     elif os.path.exists(fallback_path):
-        info('Resolving env file: {}'.format(cyan(dotenv_path)))
+        info('Resolving env file: {}'.format(cyan(fallback_path)))
         dotenv.load_dotenv(fallback_path)
 
 


### PR DESCRIPTION
The `Resolving env file: .env.<stage>` would be incorrectly printed even if only `.env` file exists, which is misleading. **This has been fixed.**