### PR TITLE
Fix the build directory not found issue on deployment

### DIFF
--- a/boss/api/deployment/buildman.py
+++ b/boss/api/deployment/buildman.py
@@ -46,19 +46,18 @@ def resolve_local_build_dir():
     config = get_stage_config(shell.get_stage())
     build_dir = config['deployment']['build_dir']
 
-    if not build_dir:
-        # Look up for fallback local directories, if it's not provided.
-        for folder in LOCAL_BUILD_DIRECTORIES:
-            if os.path.exists(folder):
-                return folder
-
-    elif build_dir and os.path.exists(build_dir):
-        # If build_dir is provided and it exists, return it.
+    # If build_dir is configured, just return it.
+    if build_dir:
         return build_dir
 
-    halt('Build directory doesn\'t exist "{}"'.format(build_dir))
+    # Look up for fallback local directories, if build_dir isn't provided.
+    for folder in LOCAL_BUILD_DIRECTORIES:
+        if os.path.exists(folder):
+            return folder
 
-    return None
+    # If fallback directories don't exist either,
+    # return one of the default build directories.
+    return LOCAL_BUILD_DIRECTORIES[0]
 
 
 def get_release_dir():

--- a/tests/api/deployment/test_buildman.py
+++ b/tests/api/deployment/test_buildman.py
@@ -10,8 +10,6 @@ def test_resolve_local_build_dir_when_build_dir_is_configured(gsc_mock):
     Test resolve_local_build_dir() returns configured value if build_dir is configured.
     '''
 
-    # with patch('boss.api.deployment.buildman.get_stage_config') as gsc_mock:
-
     test_build_dir = 'my-build-directory'
     gsc_mock.return_value = {
         'deployment': {
@@ -40,3 +38,23 @@ def test_resolve_local_build_dir_when_build_dir_is_none(gsc_mock, exists_mock):
     result = buildman.resolve_local_build_dir()
 
     assert result in buildman.LOCAL_BUILD_DIRECTORIES
+
+
+@patch('os.path.exists')
+@patch('boss.api.deployment.buildman.get_stage_config')
+def test_resolve_local_build_dir_when_build_dir_none_with_fallback_directory(gsc_mock, exists_mock):
+    '''
+    Test resolve_local_build_dir(), when build_dir is not configured,
+    but one of the fallback directories exist locally. It should return,
+    the existing directory name.
+    '''
+    exists_mock.return_value = True
+    gsc_mock.return_value = {
+        'deployment': {
+            'build_dir': None
+        }
+    }
+
+    result = buildman.resolve_local_build_dir()
+
+    assert result in buildman.LOCAL_BUILD_DIRECTORIES[0]

--- a/tests/api/deployment/test_buildman.py
+++ b/tests/api/deployment/test_buildman.py
@@ -1,0 +1,21 @@
+''' Tests for boss.api.deployment.buildman module. '''
+
+from mock import patch
+
+
+@patch('boss.config.get_stage_config')
+def test_resolve_local_build_dir_when_build_dir_is_configured(stage_config_mock):
+    '''
+    Test resolve_local_build_dir() returns configured value if build_dir is configured.
+    '''
+
+    from boss.api.deployment import buildman
+
+    test_build_dir = 'my-build-directory'
+    stage_config_mock.return_value = {
+        'deployment': {
+            'build_dir': test_build_dir
+        }
+    }
+
+    assert buildman.resolve_local_build_dir() == test_build_dir

--- a/tests/api/deployment/test_buildman.py
+++ b/tests/api/deployment/test_buildman.py
@@ -1,21 +1,42 @@
 ''' Tests for boss.api.deployment.buildman module. '''
 
 from mock import patch
+from boss.api.deployment import buildman
 
 
-@patch('boss.config.get_stage_config')
-def test_resolve_local_build_dir_when_build_dir_is_configured(stage_config_mock):
+@patch('boss.api.deployment.buildman.get_stage_config')
+def test_resolve_local_build_dir_when_build_dir_is_configured(gsc_mock):
     '''
     Test resolve_local_build_dir() returns configured value if build_dir is configured.
     '''
 
-    from boss.api.deployment import buildman
+    # with patch('boss.api.deployment.buildman.get_stage_config') as gsc_mock:
 
     test_build_dir = 'my-build-directory'
-    stage_config_mock.return_value = {
+    gsc_mock.return_value = {
         'deployment': {
             'build_dir': test_build_dir
         }
     }
 
     assert buildman.resolve_local_build_dir() == test_build_dir
+
+
+@patch('os.path.exists')
+@patch('boss.api.deployment.buildman.get_stage_config')
+def test_resolve_local_build_dir_when_build_dir_is_none(gsc_mock, exists_mock):
+    '''
+    Test resolve_local_build_dir() returns one of the default
+    build directories, if build_dir is not provided and
+    fallback directories don't exist either.
+    '''
+    exists_mock.return_value = False
+    gsc_mock.return_value = {
+        'deployment': {
+            'build_dir': None
+        }
+    }
+
+    result = buildman.resolve_local_build_dir()
+
+    assert result in buildman.LOCAL_BUILD_DIRECTORIES


### PR DESCRIPTION
* Fix the `Build directory doesn't exist "build/"` deployment issue.
* Add tests to make sure `buildman.resolve_local_build_dir()` and the bug fix works correctly.