### PR TITLE
Ability to cache builds on deployments

### DIFF
--- a/boss/cli.py
+++ b/boss/cli.py
@@ -5,6 +5,7 @@ from .core import initializer
 
 INTERACTIVE_INIT_HELP = 'Start an interactive session to compose config file'
 
+
 @click.version_option(__version__, message='%(version)s')
 @click.group()
 def main():
@@ -16,6 +17,7 @@ def main():
 @click.option('--interactive', '-i', is_flag=True, help=INTERACTIVE_INIT_HELP)
 def init(interactive):
     ''' Initialize a project directory for boss. '''
+    initializer.setup_boss_home()
     files_written = initializer.initialize(interactive)
 
     if not files_written:

--- a/boss/config.py
+++ b/boss/config.py
@@ -64,12 +64,13 @@ def merge_config(raw_config):
     preset_defaults = PRESET_SPECIFIC_DEFAULTS[preset]
     all_defaults = merge(DEFAULT_CONFIG, preset_defaults)
     merged_config = merge(all_defaults, raw_config)
+    base_config = get_base_config()
 
     # Add base config to each of the stage config
     for (stage_name, _) in merged_config['stages'].items():
-        merged_config['stages'][stage_name].update(
-            get_stage_config(stage_name)
-        )
+        stage_config = merged_config['stages'][stage_name]
+        merged_stage_config = merge(base_config, stage_config)
+        merged_config['stages'][stage_name].update(merged_stage_config)
 
     return merged_config
 
@@ -114,10 +115,7 @@ def get_base_config():
 def get_stage_config(stage):
     ''' Retrieve the configuration for the given stage. '''
     try:
-        stage_config = _config['stages'][stage]
-        base_config = get_base_config()
-
-        return merge(base_config, stage_config)
+        return _config['stages'][stage]
     except KeyError:
         halt('Unknown stage %s. Stage should be any one of %s' % (
             stage, _config['stages'].keys()

--- a/boss/config.py
+++ b/boss/config.py
@@ -68,6 +68,9 @@ def load(filename=DEFAULT_CONFIG_FILE, stage=None):
 
             return get()
 
+    except KeyError:
+        halt('Invalid configuration file "{}"'.format(filename))
+
     except IOError:
         halt('Error loading config file "%s"' % filename)
 

--- a/boss/config.py
+++ b/boss/config.py
@@ -63,16 +63,16 @@ def merge_config(raw_config):
     preset = get_deployment_preset(raw_config)
     preset_defaults = PRESET_SPECIFIC_DEFAULTS[preset]
     all_defaults = merge(DEFAULT_CONFIG, preset_defaults)
-    merged_config = merge(all_defaults, raw_config)
-    base_config = get_base_config()
+    result = merge(all_defaults, raw_config)
+    base_config = get_base_config(result)
 
     # Add base config to each of the stage config
-    for (stage_name, _) in merged_config['stages'].items():
-        stage_config = merged_config['stages'][stage_name]
+    for (stage_name, _) in result['stages'].items():
+        stage_config = result['stages'][stage_name]
         merged_stage_config = merge(base_config, stage_config)
-        merged_config['stages'][stage_name].update(merged_stage_config)
+        result['stages'][stage_name].update(merged_stage_config)
 
-    return merged_config
+    return result
 
 
 def load(filename=DEFAULT_CONFIG_FILE, stage=None):
@@ -100,15 +100,17 @@ def load(filename=DEFAULT_CONFIG_FILE, stage=None):
         halt('Error loading config file "%s"' % filename)
 
 
-def get_base_config():
+def get_base_config(resolved_config=None):
     ''' Get the base configuration. '''
+    config = resolved_config or _config
+
     return {
-        'user': _config.get('user'),
-        'port': _config.get('port'),
-        'branch': _config.get('branch'),
-        'app_dir': _config.get('app_dir'),
-        'repository_url': _config.get('repository_url'),
-        'deployment': _config.get('deployment')
+        'user': config.get('user'),
+        'port': config.get('port'),
+        'branch': config.get('branch'),
+        'app_dir': config.get('app_dir'),
+        'repository_url': config.get('repository_url'),
+        'deployment': config.get('deployment')
     }
 
 

--- a/boss/config.py
+++ b/boss/config.py
@@ -39,6 +39,21 @@ def resolve_dotenv_file(path, stage=None):
         dotenv.load_dotenv(fallback_path)
 
 
+def get_deployment_preset(raw_config):
+    ''' Get the deployment preset for a raw config. '''
+    has_preset = (
+        isinstance(raw_config.get('deployment'), dict) and
+        'preset' in raw_config.get('deployment')
+    )
+
+    # If preset is configured return it.
+    if has_preset:
+        return raw_config['deployment']['preset']
+
+    # Else return the default deployment config preset.
+    return DEFAULT_CONFIG['deployment']['preset']
+
+
 def load(filename=DEFAULT_CONFIG_FILE, stage=None):
     ''' Load the configuration and return it. '''
     try:
@@ -53,8 +68,7 @@ def load(filename=DEFAULT_CONFIG_FILE, stage=None):
 
             # Merge the default config along with preset specific defaults
             # to the loaded config.
-            preset = loaded_config['deployment'].get('preset') or DEFAULT_CONFIG[
-                'deployment']['preset']
+            preset = get_deployment_preset(loaded_config)
             preset_defaults = PRESET_SPECIFIC_DEFAULTS[preset]
             all_defaults = merge(DEFAULT_CONFIG, preset_defaults)
             merged_config = merge(all_defaults, loaded_config)

--- a/boss/constants.py
+++ b/boss/constants.py
@@ -1,5 +1,7 @@
 ''' Application wide common constants module. '''
 
+from os.path import expanduser
+
 # Predefined deployment presets
 PRESET_WEB = 'web'
 PRESET_NODE = 'node'
@@ -8,6 +10,11 @@ PRESET_REMOTE_SOURCE = 'remote-source'
 # Default boss configuration
 DEFAULT_CONFIG_FILE = 'boss.yml'
 FABFILE_PATH = 'fabfile.py'
+
+# Boss paths
+BOSS_HOME_PATH = expanduser('~/.boss')
+BOSS_CACHE_PATH = BOSS_HOME_PATH + '/cache'
+
 DEFAULT_CONFIG = {
     'user': 'boss',
     'port': 22,

--- a/boss/constants.py
+++ b/boss/constants.py
@@ -63,10 +63,15 @@ SCRIPT_INSTALL_REMOTE = 'install_remote'
 SCRIPT_START_OR_RELOAD = 'start_or_reload'
 
 
-# Preset specific defaults
+# Preset specific default configurations.
+# These will override the DEFAULT_CONFIG values for the configured preset.
 PRESET_SPECIFIC_DEFAULTS = {
     PRESET_REMOTE_SOURCE: {},
-    PRESET_WEB: {},
+    PRESET_WEB: {
+        'deployment': {
+            'cache_builds': False
+        }
+    },
     PRESET_NODE: {
         'deployment': {
             'include_files': [

--- a/boss/constants.py
+++ b/boss/constants.py
@@ -26,6 +26,7 @@ DEFAULT_CONFIG = {
         'preset': PRESET_REMOTE_SOURCE,
         'build_dir': None,
         'base_dir': '~/boss',
+        'cache_builds': True,
         'keep_builds': 5,
         'include_files': []
     },

--- a/boss/core/fs.py
+++ b/boss/core/fs.py
@@ -2,6 +2,7 @@
 Boss core file system utilities.
 '''
 import os
+import tarfile
 
 
 def read(filename):
@@ -19,3 +20,9 @@ def write(filename, data):
 def exists(path):
     ''' Check if file path exists. '''
     return os.path.exists(path)
+
+
+def compress(source_dir, name):
+    ''' Compress a directory and build an archive (Tar zipped). '''
+    with tarfile.open(name, 'w:gz') as tar:
+        tar.add(source_dir, arcname=os.path.basename(source_dir))

--- a/boss/core/initializer.py
+++ b/boss/core/initializer.py
@@ -2,10 +2,17 @@
 Module to deal with the initialization of environment
 for boss i.e generating config files and fabfile.
 '''
+from os import mkdir
 
 from boss import BASE_PATH
 from boss.core import fs
-from boss.constants import DEFAULT_CONFIG, DEFAULT_CONFIG_FILE, FABFILE_PATH
+from boss.constants import (
+    FABFILE_PATH,
+    BOSS_HOME_PATH,
+    BOSS_CACHE_PATH,
+    DEFAULT_CONFIG,
+    DEFAULT_CONFIG_FILE
+)
 
 from boss.core.inquiries import get_initial_config_params
 
@@ -70,3 +77,15 @@ def initialize_fabfile():
         fs.write(fabfile, fabfile_tmpl)
 
         return fabfile
+
+
+def setup_boss_home():
+    '''
+    Sets up boss home directory on the user's local machine.
+    If the directory already exists, it's skipped.
+    '''
+    if not fs.exists(BOSS_HOME_PATH):
+        mkdir(BOSS_HOME_PATH)
+
+    if not fs.exists(BOSS_CACHE_PATH):
+        mkdir(BOSS_CACHE_PATH)

--- a/boss/core/initializer.py
+++ b/boss/core/initializer.py
@@ -9,6 +9,7 @@ from boss.constants import DEFAULT_CONFIG, DEFAULT_CONFIG_FILE, FABFILE_PATH
 
 from boss.core.inquiries import get_initial_config_params
 
+
 def initialize(interactive):
     ''' Initialize the local project directory for boss. '''
     files_written = []

--- a/boss/core/inquiries.py
+++ b/boss/core/inquiries.py
@@ -5,6 +5,7 @@ from inquirer import Text, List, prompt
 
 from boss.constants import DEFAULT_CONFIG, PRESET_NODE, PRESET_REMOTE_SOURCE, PRESET_WEB
 
+
 def get_initial_config_params():
     ''' Get initial config params from user. '''
 
@@ -24,19 +25,19 @@ def get_initial_config_params():
             'ssh_port',
             message='Enter SSH port',
             default=DEFAULT_CONFIG['port']
-            ),
+        ),
 
         List(
             'deployment_preset',
             message='Select your deployment preset',
             choices=[PRESET_WEB, PRESET_NODE, PRESET_REMOTE_SOURCE]
-            ),
+        ),
 
         Text(
             'deployment_base_dir',
             message='Enter your base directory for deployment',
             default=DEFAULT_CONFIG['deployment']['base_dir']
-            )
+        )
     ]
 
     answers = prompt(questions)

--- a/boss/init.py
+++ b/boss/init.py
@@ -6,12 +6,14 @@ from fabric.tasks import _is_task
 
 
 from .config import load as load_config, get as get_config, get_stage_config
+from .core.initializer import setup_boss_home
 from .api.shell import get_stage
 from .api.deployment import deployer
 
 
 def init(module_name):
     ''' Initialize the boss configuration. '''
+    setup_boss_home()
     stage = get_stage()
     config = load_config(stage=stage)
 

--- a/tests/core/test_initializer.py
+++ b/tests/core/test_initializer.py
@@ -1,6 +1,8 @@
 ''' Tests for boss.core.initializer module. '''
 
-from mock import patch
+from mock import patch, call
+
+from boss.constants import BOSS_HOME_PATH, BOSS_CACHE_PATH
 from boss.core import initializer
 
 
@@ -23,3 +25,18 @@ def test_initialize_if_no_files_exist(mock_exists, mock_write):
     files_written = initializer.initialize(interactive_flag)
 
     assert len(files_written) == mock_write.call_count
+
+
+@patch('boss.core.fs.exists')
+@patch('boss.core.initializer.mkdir')
+def test_setup_boss_home(mock_mkdir, mock_exists):
+    '''
+    Test directories are created if
+    boss home path doesn't exist.
+    '''
+    mock_exists.return_value = False
+    initializer.setup_boss_home()
+    mock_mkdir.assert_has_calls([
+        call(BOSS_HOME_PATH),
+        call(BOSS_CACHE_PATH)
+    ])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,7 +5,11 @@ from click.testing import CliRunner
 
 from boss import __version__
 from boss.cli import main as cli
-from boss.constants import DEFAULT_CONFIG_FILE, FABFILE_PATH
+from boss.constants import (
+    DEFAULT_CONFIG_FILE, FABFILE_PATH,
+    BOSS_HOME_PATH,
+    BOSS_CACHE_PATH
+)
 
 
 def test_version_option():
@@ -18,12 +22,17 @@ def test_version_option():
 
 
 def test_init_command():
-    ''' Test init command generates files. '''
+    '''
+    Test init command generates config files and
+    doees setup boss home directory.
+    '''
     runner = CliRunner()
 
     with runner.isolated_filesystem():
         result = runner.invoke(cli, ['init'])
 
         assert result.exit_code == 0
+        assert os.path.exists(BOSS_HOME_PATH)
+        assert os.path.exists(BOSS_CACHE_PATH)
         assert os.path.exists(FABFILE_PATH)
         assert os.path.exists(DEFAULT_CONFIG_FILE)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,31 @@
+''' Unit tests for boss.config module. '''
+
+from boss.config import get_deployment_preset, DEFAULT_CONFIG
+
+
+def test_get_deployment_preset_returns_configured_preset():
+    '''
+    Check get_deployment_preset() function returns
+    the configured deployment preset if it is configured.
+    '''
+    raw_config = {
+        'deployment': {
+            'preset': 'test-preset'
+        }
+    }
+    preset = get_deployment_preset(raw_config)
+
+    assert preset == 'test-preset'
+
+
+def test_get_deployment_preset_returns_default_preset_if_not_set():
+    '''
+    Check get_deployment_preset() function returns,
+    the default deployment preset if it is not configured.
+    '''
+    raw_config = {
+        'project_name': 'test-project'
+    }
+    preset = get_deployment_preset(raw_config)
+
+    assert preset == DEFAULT_CONFIG['deployment']['preset']

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,10 @@
 ''' Unit tests for boss.config module. '''
 
-from boss.config import get_deployment_preset, DEFAULT_CONFIG
+from boss.constants import DEFAULT_CONFIG, PRESET_WEB
+from boss.config import (
+    merge_config,
+    get_deployment_preset
+)
 
 
 def test_get_deployment_preset_returns_configured_preset():
@@ -29,3 +33,29 @@ def test_get_deployment_preset_returns_default_preset_if_not_set():
     preset = get_deployment_preset(raw_config)
 
     assert preset == DEFAULT_CONFIG['deployment']['preset']
+
+
+def test_merge_config_that_by_default_cache_builds_is_true():
+    '''
+    Ensure build caching is turned on, i.e
+    cache_build=True by default if not set.
+    '''
+    raw_config = {}
+    merged_config = merge_config(raw_config)
+
+    assert merged_config['deployment']['cache_builds'] is True
+
+
+def test_merge_config_that_by_default_cache_builds_is_false_if_preset_web():
+    '''
+    Ensure build caching is turned off for web preset, i.e
+    cache_build=False by default if not set.
+    '''
+    raw_config = {
+        'deployment': {
+            'preset': PRESET_WEB
+        }
+    }
+    merged_config = merge_config(raw_config)
+
+    assert merged_config['deployment']['cache_builds'] is False

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -93,3 +93,40 @@ def test_merge_config_that_default_config_could_be_overridden():
     # Not overridden, uses default values.
     assert result['user'] == DEFAULT_CONFIG['user']
     assert result['deployment']['preset'] == DEFAULT_CONFIG['deployment']['preset']
+
+
+def test_merge_config_base_config_is_merged_to_each_stage_specfic_config():
+    '''
+    Ensure the base deployment config and basic config are merged to
+    each of the stage configurations
+    '''
+    raw_config = {
+        'port': '1234',
+        'deployment': {
+            'base_dir': '~/some/directory'
+        },
+        'stages': {
+            'stage1': {
+                'host': 'stage1.example.com'
+            },
+            'stage2': {
+                'host': 'stage2.example.com',
+                'port': '4321'
+            }
+        }
+    }
+    result = merge_config(raw_config)
+
+    # Stage1
+    stage1_config = result['stages']['stage1']
+    assert stage1_config['port'] == raw_config['port']
+    assert stage1_config['host'] == raw_config['stages']['stage1']['host']
+    assert stage1_config['deployment']['base_dir'] == raw_config['deployment']['base_dir']
+    assert stage1_config['deployment']['build_dir'] == DEFAULT_CONFIG['deployment']['build_dir']
+
+    # Stage 2
+    stage2_config = result['stages']['stage2']
+    assert stage2_config['port'] == raw_config['stages']['stage2']['port']
+    assert stage2_config['host'] == raw_config['stages']['stage2']['host']
+    assert stage2_config['deployment']['base_dir'] == raw_config['deployment']['base_dir']
+    assert stage2_config['deployment']['build_dir'] == DEFAULT_CONFIG['deployment']['build_dir']

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -71,3 +71,25 @@ def test_merge_config_that_default_config_values_are_put():
     assert result['user'] == DEFAULT_CONFIG['user']
     assert result['port'] == DEFAULT_CONFIG['port']
     assert result['deployment'] == DEFAULT_CONFIG['deployment']
+
+
+def test_merge_config_that_default_config_could_be_overridden():
+    '''
+    Ensure default config values could be overridden for the
+    config options that are set, however the rest of the options
+    that aren't set would still take default values.
+    '''
+    raw_config = {
+        'port': '1234',
+        'deployment': {
+            'base_dir': '~/some/directory'
+        }
+    }
+    result = merge_config(raw_config)
+
+    assert result['port'] == raw_config['port']
+    assert result['deployment']['base_dir'] == raw_config['deployment']['base_dir']
+
+    # Not overridden, uses default values.
+    assert result['user'] == DEFAULT_CONFIG['user']
+    assert result['deployment']['preset'] == DEFAULT_CONFIG['deployment']['preset']

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -59,3 +59,15 @@ def test_merge_config_that_by_default_cache_builds_is_false_if_preset_web():
     merged_config = merge_config(raw_config)
 
     assert merged_config['deployment']['cache_builds'] is False
+
+
+def test_merge_config_that_default_config_values_are_put():
+    '''
+    Ensure default values are put if config options are not provided.
+    '''
+    raw_config = {}
+    result = merge_config(raw_config)
+
+    assert result['user'] == DEFAULT_CONFIG['user']
+    assert result['port'] == DEFAULT_CONFIG['port']
+    assert result['deployment'] == DEFAULT_CONFIG['deployment']


### PR DESCRIPTION
* Add `cache_builds` config option. Defaults to `true` for all presets except for `preset: web`.
* Refactor `boss.config` module with added tests.
* Ability to cache builds on deployment.

**Work In Progress**