### PR TITLE
Use git tree url for commit and branche links in the notification message

### DIFF
--- a/boss/api/git.py
+++ b/boss/api/git.py
@@ -65,6 +65,14 @@ def get_commit_url(commit, repository_url):
     )
 
 
+def get_tree_url(ref, repository_url):
+    ''' Get a link for a ref (commit, branch or tag) for the repository. '''
+    return '{repository_url}/tree/{ref}'.format(
+        repository_url=repository_url,
+        ref=ref
+    )
+
+
 def show_last_commit():
     ''' Display the last commit. '''
     run('git log -1')

--- a/boss/api/notif.py
+++ b/boss/api/notif.py
@@ -4,7 +4,7 @@ Notification API module.
 
 from ..util import remote_info
 from . import slack, hipchat, git
-from ..config import get_branch_url, get_stage_config, get as get_config
+from ..config import get_stage_config, get as get_config
 
 # Notification Services
 notifiers = [slack, hipchat]
@@ -30,7 +30,7 @@ def extract_notification_params(params):
     ''' Extract parameters for notification. '''
     config = get_config()
     stage_config = get_stage_config(params['stage'])
-    commit_url = git.get_commit_url(params['commit'], config['repository_url'])
+    commit_url = git.get_tree_url(params['commit'], config['repository_url'])
 
     notif_params = dict(
         user=params['user'],
@@ -51,6 +51,7 @@ def extract_notification_params(params):
     # So, just hide the branch in those cases.
     if params.get('branch') and params.get('branch') != 'HEAD':
         notif_params['branch'] = params['branch']
-        notif_params['branch_url'] = get_branch_url(params['branch'])
+        notif_params['branch_url'] = git.get_tree_url(
+            params['branch'], config['repository_url'])
 
     return notif_params

--- a/boss/config.py
+++ b/boss/config.py
@@ -131,11 +131,3 @@ def get_stage_config(stage):
 def fallback_branch(stage):
     ''' Get the fallback branch for the stage. '''
     return get_stage_config(stage).get('branch') or _config['branch']
-
-
-def get_branch_url(branch):
-    ''' Get the branch url to view it on the Web (eg: GitHub, GitLab etc.). '''
-    return _config['branch_url'].format(
-        repository_url=_config['repository_url'],
-        branch=branch
-    )

--- a/tests/api/test_notif.py
+++ b/tests/api/test_notif.py
@@ -17,7 +17,7 @@ from boss.constants import (
 def test_notif_sends_slack_notification(slack_send_m, slack_is_enabled_m, gsc_m, get_m, _):
     ''' Test notif.send sends slack notification if slack is enabled. '''
     commit = 't12345'
-    commit_url = 'https://github.com/kabirbaidhya/boss/commit/t12345'
+    commit_url = 'https://github.com/kabirbaidhya/boss/tree/t12345'
     get_m.return_value = {
         'project_name': 'test-project',
         'project_description': 'Just a test project',
@@ -28,6 +28,7 @@ def test_notif_sends_slack_notification(slack_send_m, slack_is_enabled_m, gsc_m,
         'host': 'example.com'
     }
     slack_is_enabled_m.return_value = True
+    branch_url = 'https://github.com/kabirbaidhya/boss/tree/my-branch'
 
     # Trigger deployment started notification
     notif.send(NOTIFICATION_DEPLOYMENT_STARTED, {
@@ -51,7 +52,7 @@ def test_notif_sends_slack_notification(slack_send_m, slack_is_enabled_m, gsc_m,
             branch='my-branch',
             commit=commit,
             commit_url=commit_url,
-            branch_url='/branch/my-branch',
+            branch_url=branch_url,
             host='example.com',
             project_description='Just a test project',
             project_name='test-project',
@@ -83,7 +84,7 @@ def test_notif_sends_slack_notification(slack_send_m, slack_is_enabled_m, gsc_m,
 def test_notif_sends_hipchat_notification(hipchat_send_m, hipchat_is_enabled_m, gsc_m, get_m, _):
     ''' Test notif.send sends hipchat notification if hipchat is enabled. '''
     commit = 't12345'
-    commit_url = 'https://github.com/kabirbaidhya/boss/commit/t12345'
+    commit_url = 'https://github.com/kabirbaidhya/boss/tree/t12345'
     get_m.return_value = {
         'project_name': 'test-project',
         'project_description': 'Just a test project',
@@ -94,6 +95,7 @@ def test_notif_sends_hipchat_notification(hipchat_send_m, hipchat_is_enabled_m, 
         'host': 'example.com'
     }
     hipchat_is_enabled_m.return_value = True
+    branch_url = 'https://github.com/kabirbaidhya/boss/tree/my-branch'
 
     # Trigger deployment finished notification
     notif.send(NOTIFICATION_DEPLOYMENT_FINISHED, {
@@ -116,7 +118,7 @@ def test_notif_sends_hipchat_notification(hipchat_send_m, hipchat_is_enabled_m, 
             branch='my-branch',
             commit=commit,
             commit_url=commit_url,
-            branch_url='/branch/my-branch',
+            branch_url=branch_url,
             host='example.com',
             project_description='Just a test project',
             project_name='test-project',


### PR DESCRIPTION
* Commit links go to repository tree for that commit
* Branch links go to repository tree for that branch