### PR TITLE
Use separate colors for notification messages for CI and manual deployments

### DIFF
--- a/boss/api/hipchat.py
+++ b/boss/api/hipchat.py
@@ -60,89 +60,65 @@ def notify(payload):
     requests.post(url, json=payload)
 
 
+def get_notif_params(**params):
+    ''' Get hipchat notification params. '''
+    result = dict(
+        user=params['user'],
+        project_link=create_link(
+            params['repository_url'],
+            params['project_name']
+        ),
+        commit_link=create_link(
+            params['commit_url'],
+            params['commit']
+        ),
+        server_link=create_link(
+            params['public_url'], params['server_name']
+        )
+    )
+
+    if params.get('branch_url') and params.get('branch'):
+        result['branch_link'] = create_link(
+            params['branch_url'],
+            params['branch']
+        )
+
+    return result
+
+
 def notify_deploying(**params):
     ''' Send Deploying notification on Hipchat. '''
-
-    project_link = create_link(
-        params['repository_url'],
-        params['project_name']
-    )
-    commit_link = create_link(
-        params['commit_url'],
-        params['commit']
-    )
-    server_short_link = create_link(
-        params['public_url'], params['server_name']
-    )
+    notification = get_notif_params(**params)
 
     # If the branch is provided, display branch name in the message.
-    if params.get('branch_url') and params.get('branch'):
-        branch_link = create_link(params['branch_url'], params['branch'])
-        text = DEPLOYING_MESSAGE_WITH_BRANCH.format(
-            user=params['user'],
-            branch_link=branch_link,
-            commit_link=commit_link,
-            project_link=project_link,
-            server_link=server_short_link
-        )
+    if notification.has_key('branch_link'):
+        text = DEPLOYING_MESSAGE_WITH_BRANCH.format(**notification)
     else:
-        text = DEPLOYING_MESSAGE.format(
-            user=params['user'],
-            project_link=project_link,
-            commit_link=commit_link,
-            server_link=server_short_link
-        )
+        text = DEPLOYING_MESSAGE.format(**notification)
 
-    payload = {
+    # Notify on hipchat
+    notify({
         'color': config()['deploying_color'],
         'message': text,
         'notify': config()['notify'],
         'message_format': 'html'
-    }
-
-    # Notify on hipchat
-    notify(payload)
+    })
 
 
 def notify_deployed(**params):
     ''' Send Deployed notification on Hipchat. '''
-    server_short_link = create_link(
-        params['public_url'],
-        params['server_name']
-    )
-    commit_link = create_link(
-        params['commit_url'],
-        params['commit']
-    )
-    project_link = create_link(
-        params['repository_url'],
-        params['project_name']
-    )
+    notification = get_notif_params(**params)
 
     # If the branch is provided, display branch name in the message.
-    if params.get('branch_url') and params.get('branch'):
-        branch_link = create_link(params['branch_url'], params['branch'])
-        text = DEPLOYED_SUCCESS_MESSAGE_WITH_BRANCH.format(
-            user=params['user'],
-            branch_link=branch_link,
-            commit_link=commit_link,
-            project_link=project_link,
-            server_link=server_short_link
-        )
+    if notification.has_key('branch_link'):
+        text = DEPLOYED_SUCCESS_MESSAGE_WITH_BRANCH.format(**notification)
     else:
-        text = DEPLOYED_SUCCESS_MESSAGE.format(
-            user=params['user'],
-            commit_link=commit_link,
-            project_link=project_link,
-            server_link=server_short_link
-        )
+        text = DEPLOYED_SUCCESS_MESSAGE.format(**notification)
 
-    payload = {
+    # Notify on hipchat
+    notify({
         'color': config()['deployed_color'],
         'message': text,
         'notify': config()['notify'],
         'message_format': 'html'
-    }
-
-    # Notify on hipchat
-    notify(payload)
+    })

--- a/boss/api/hipchat.py
+++ b/boss/api/hipchat.py
@@ -5,6 +5,7 @@ Module for hipchat API.
 import requests
 from ..config import get as _get_config
 
+from boss.core.ci import is_ci
 from boss.constants import (
     NOTIFICATION_DEPLOYMENT_STARTED,
     NOTIFICATION_DEPLOYMENT_FINISHED
@@ -96,9 +97,14 @@ def notify_deploying(**params):
     else:
         text = DEPLOYING_MESSAGE.format(**notification)
 
+    if is_ci():
+        color = config()['ci_deploying_color']
+    else:
+        color = config()['deploying_color']
+
     # Notify on hipchat
     notify({
-        'color': config()['deploying_color'],
+        'color': color,
         'message': text,
         'notify': config()['notify'],
         'message_format': 'html'
@@ -115,9 +121,14 @@ def notify_deployed(**params):
     else:
         text = DEPLOYED_SUCCESS_MESSAGE.format(**notification)
 
+    if is_ci():
+        color = config()['ci_deployed_color']
+    else:
+        color = config()['deployed_color']
+
     # Notify on hipchat
     notify({
-        'color': config()['deployed_color'],
+        'color': color,
         'message': text,
         'notify': config()['notify'],
         'message_format': 'html'

--- a/boss/api/slack.py
+++ b/boss/api/slack.py
@@ -6,6 +6,7 @@ Module for slack API.
 import requests
 from ..config import get as _get_config
 
+from boss.core.ci import is_ci
 from boss.constants import (
     NOTIFICATION_DEPLOYMENT_STARTED,
     NOTIFICATION_DEPLOYMENT_FINISHED
@@ -90,11 +91,16 @@ def notify_deploying(**params):
     else:
         text = DEPLOYING_MESSAGE.format(**notification)
 
+    if is_ci():
+        color = config()['ci_deploying_color']
+    else:
+        color = config()['deploying_color']
+
     # Notify on slack
     notify({
         'attachments': [
             {
-                'color': config()['deploying_color'],
+                'color': color,
                 'text': text
             }
         ]
@@ -112,11 +118,16 @@ def notify_deployed(**params):
     else:
         text = DEPLOYED_SUCCESS_MESSAGE.format(**notification)
 
+    if is_ci():
+        color = config()['ci_deployed_color']
+    else:
+        color = config()['deployed_color']
+
     # Notify on slack
     notify({
         'attachments': [
             {
-                'color': config()['deployed_color'],
+                'color': color,
                 'text': text
             }
         ]

--- a/boss/api/slack.py
+++ b/boss/api/slack.py
@@ -53,94 +53,71 @@ def notify(payload):
     requests.post(url, json=payload)
 
 
+def get_notif_params(**params):
+    ''' Get slack notification params. '''
+    result = dict(
+        user=params['user'],
+        project_link=create_link(
+            params['repository_url'],
+            params['project_name']
+        ),
+        commit_link=create_link(
+            params['commit_url'],
+            params['commit']
+        ),
+        server_link=create_link(
+            params['public_url'], params['server_name']
+        )
+    )
+
+    if params.get('branch_url') and params.get('branch'):
+        result['branch_link'] = create_link(
+            params['branch_url'],
+            params['branch']
+        )
+
+    return result
+
+
 def notify_deploying(**params):
     ''' Send Deploying notification on Slack. '''
 
-    commit_link = create_link(
-        params['commit_url'],
-        params['commit']
-    )
-    project_link = create_link(
-        params['repository_url'],
-        params['project_name']
-    )
-    server_short_link = create_link(
-        params['public_url'], params['server_name']
-    )
+    notification = get_notif_params(**params)
 
     # If the branch is provided, display branch name in the message.
-    if params.get('branch_url') and params.get('branch'):
-        branch_link = create_link(params['branch_url'], params['branch'])
-        text = DEPLOYING_MESSAGE_WITH_BRANCH.format(
-            user=params['user'],
-            commit_link=commit_link,
-            branch_link=branch_link,
-            project_link=project_link,
-            server_link=server_short_link
-        )
+    if notification.has_key('branch_link'):
+        text = DEPLOYING_MESSAGE_WITH_BRANCH.format(**notification)
     else:
-        text = DEPLOYING_MESSAGE.format(
-            user=params['user'],
-            commit_link=commit_link,
-            project_link=project_link,
-            server_link=server_short_link
-        )
+        text = DEPLOYING_MESSAGE.format(**notification)
 
-    payload = {
+    # Notify on slack
+    notify({
         'attachments': [
             {
                 'color': config()['deploying_color'],
                 'text': text
             }
         ]
-    }
-
-    # Notify on slack
-    notify(payload)
+    })
 
 
 def notify_deployed(**params):
     ''' Send Deployed notification on Slack. '''
 
-    commit_link = create_link(
-        params['commit_url'],
-        params['commit']
-    )
-    server_short_link = create_link(
-        params['public_url'],
-        params['server_name']
-    )
-    project_link = create_link(
-        params['repository_url'],
-        params['project_name']
-    )
+    notification = get_notif_params(**params)
 
     # If the branch is provided, display branch name in the message.
-    if params.get('branch_url') and params.get('branch'):
-        branch_link = create_link(params['branch_url'], params['branch'])
-        text = DEPLOYED_SUCCESS_MESSAGE_WITH_BRANCH.format(
-            user=params['user'],
-            branch_link=branch_link,
-            commit_link=commit_link,
-            project_link=project_link,
-            server_link=server_short_link
-        )
+    if notification.has_key('branch_link'):
+        text = DEPLOYED_SUCCESS_MESSAGE_WITH_BRANCH.format(**notification)
     else:
-        text = DEPLOYED_SUCCESS_MESSAGE.format(
-            user=params['user'],
-            commit_link=commit_link,
-            project_link=project_link,
-            server_link=server_short_link
-        )
+        text = DEPLOYED_SUCCESS_MESSAGE.format(**notification)
 
-    payload = {
+    # Notify on slack
+    notify({
         'attachments': [
             {
                 'color': config()['deployed_color'],
                 'text': text
             }
         ]
-    }
-
-    # Notify on slack
-    notify(payload)
+    })

--- a/boss/constants.py
+++ b/boss/constants.py
@@ -42,6 +42,8 @@ DEFAULT_CONFIG = {
             'endpoint': '',
             'deploying_color': 'good',
             'deployed_color': '#764FA5',
+            'ci_deploying_color': '#cccccc',
+            'ci_deployed_color': '#7CD197',
             'base_url': 'https://hooks.slack.com/services'
         },
         'hipchat': {
@@ -50,8 +52,10 @@ DEFAULT_CONFIG = {
             'company_name': '',
             'room_id': '',
             'auth_token': '',
-            'deploying_color': 'yellow',
-            'deployed_color': 'green',
+            'deploying_color': 'green',
+            'deployed_color': 'purple',
+            'ci_deploying_color': 'gray',
+            'ci_deployed_color': 'yellow',
         }
     }
 }

--- a/boss/core/ci.py
+++ b/boss/core/ci.py
@@ -7,7 +7,8 @@ def is_ci():
     ''' Check if boss is running in a Continuous Integration (CI) environment. '''
 
     return bool(
-        (env.get('CI') and env['CI'] == 'true') or
-        (env.get('CONTINUOUS_INTEGRATION')
-         and env['CONTINUOUS_INTEGRATION'] == 'true')
+        env.get('BOSS_RUNNING') == 'true' and (
+            (env.get('CI') == 'true') or
+            (env.get('CONTINUOUS_INTEGRATION') == 'true')
+        )
     )

--- a/boss/core/ci.py
+++ b/boss/core/ci.py
@@ -1,0 +1,13 @@
+''' Core module for Continuous Integration (CI) operations. '''
+
+from os import environ as env
+
+
+def is_ci():
+    ''' Check if boss is running in a Continuous Integration (CI) environment. '''
+
+    return bool(
+        (env.get('CI') and env['CI'] == 'true') or
+        (env.get('CONTINUOUS_INTEGRATION')
+         and env['CONTINUOUS_INTEGRATION'] == 'true')
+    )

--- a/boss/init.py
+++ b/boss/init.py
@@ -1,5 +1,6 @@
 ''' Initialization module. '''
 
+import os
 import sys
 from fabric.api import env, task
 from fabric.tasks import _is_task
@@ -13,6 +14,7 @@ from .api.deployment import deployer
 
 def init(module_name):
     ''' Initialize the boss configuration. '''
+    os.environ['BOSS_RUNNING'] = 'true'
     setup_boss_home()
     stage = get_stage()
     config = load_config(stage=stage)

--- a/tests/api/test_hipchat.py
+++ b/tests/api/test_hipchat.py
@@ -43,7 +43,7 @@ def test_notity_deploying():
         user='user',
     )
     payload = {
-        'color': 'yellow',
+        'color': 'green',
         'message': 'user is deploying <a href="http://repository-url">project-name</a>:<a href="http://branch-url">temp</a> (<a href="http://commit-url">tttt</a>) to <a href="http://public-url">stage</a> server.',
         'notify': True,
         'message_format': 'html'
@@ -75,7 +75,7 @@ def test_notity_deployed():
         user='user',
     )
     payload = {
-        'color': 'green',
+        'color': 'purple',
         'message': 'user finished deploying <a href="http://repository-url">project-name</a>:<a href="http://branch-url">temp</a> (<a href="http://commit-url">tttt</a>) to <a href="http://public-url">stage</a> server.',
         'notify': True,
         'message_format': 'html'
@@ -109,7 +109,7 @@ def test_notity_deploying_with_no_branch():
         user='user',
     )
     payload = {
-        'color': 'yellow',
+        'color': 'green',
         'message': 'user is deploying <a href="http://repository-url">project-name</a> (<a href="http://commit-url">tttt</a>) to <a href="http://public-url">stage</a> server.',
         'notify': True,
         'message_format': 'html'
@@ -142,7 +142,7 @@ def test_notity_deployed_with_no_branch():
         user='user',
     )
     payload = {
-        'color': 'green',
+        'color': 'purple',
         'message': 'user finished deploying <a href="http://repository-url">project-name</a> (<a href="http://commit-url">tttt</a>) to <a href="http://public-url">stage</a> server.',
         'notify': True,
         'message_format': 'html'

--- a/tests/core/test_ci.py
+++ b/tests/core/test_ci.py
@@ -1,0 +1,35 @@
+''' Tests for boss.core.ci module. '''
+
+import os
+from boss.core.ci import is_ci
+
+
+def test_is_ci_returns_true_case_1():
+    '''
+    Test is_ci() returns True if CI=true,
+    is passed through environment variables.
+    '''
+    os.environ['CI'] = 'true'
+
+    assert is_ci() is True
+
+
+def test_is_ci_returns_true_case_2():
+    '''
+    Test is_ci() returns True if CONTINUOUS_INTEGRATION=true,
+    is passed through environment variables.
+    '''
+    os.environ['CONTINUOUS_INTEGRATION'] = 'true'
+
+    assert is_ci() is True
+
+
+def test_is_ci_returns_false():
+    '''
+    Test is_ci() returns True if CONTINUOUS_INTEGRATION=true,
+    is passed through environment variables.
+    '''
+    os.environ['CI'] = ''
+    os.environ['CONTINUOUS_INTEGRATION'] = ''
+
+    assert is_ci() is False

--- a/tests/core/test_ci.py
+++ b/tests/core/test_ci.py
@@ -9,6 +9,7 @@ def test_is_ci_returns_true_case_1():
     Test is_ci() returns True if CI=true,
     is passed through environment variables.
     '''
+    os.environ['BOSS_RUNNING'] = 'true'
     os.environ['CI'] = 'true'
 
     assert is_ci() is True
@@ -19,6 +20,7 @@ def test_is_ci_returns_true_case_2():
     Test is_ci() returns True if CONTINUOUS_INTEGRATION=true,
     is passed through environment variables.
     '''
+    os.environ['BOSS_RUNNING'] = 'true'
     os.environ['CONTINUOUS_INTEGRATION'] = 'true'
 
     assert is_ci() is True
@@ -26,10 +28,22 @@ def test_is_ci_returns_true_case_2():
 
 def test_is_ci_returns_false():
     '''
-    Test is_ci() returns True if CONTINUOUS_INTEGRATION=true,
-    is passed through environment variables.
+    Test is_ci() returns False if CI related environment variables,
+    are not found.
     '''
     os.environ['CI'] = ''
     os.environ['CONTINUOUS_INTEGRATION'] = ''
+
+    assert is_ci() is False
+
+
+def test_is_ci_returns_false_if_boss_is_not_running_in_run_mode():
+    '''
+    Test is_ci() returns False if boss is not running (test environment).
+    (This is to check is_ci() function works well when these tests are running in CI).
+    '''
+    os.environ['BOSS_RUNNING'] = ''
+    os.environ['CI'] = 'true'
+    os.environ['CONTINUOUS_INTEGRATION'] = 'true'
 
     assert is_ci() is False


### PR DESCRIPTION
* Use separate colors for slack & hipchat notification messages for CI and manual deployments.
* Refactor hipchat & slack code and add tests
* Add `boss.core.ci` module and tests.