### PR TITLE
Remote env injection

### DIFF
--- a/boss/api/deployment/buildman.py
+++ b/boss/api/deployment/buildman.py
@@ -9,12 +9,12 @@ from datetime import datetime
 
 from terminaltables import SingleTable
 from fabric.colors import green, cyan
-from fabric.api import cd, hide
+from fabric.api import cd, hide, shell_env
 
 from boss import BASE_PATH, __version__ as BOSS_VERSION, constants
 from boss.config import get as get_config, get_stage_config
-from boss.util import halt, remote_info, remote_print, merge, localize_utc_timestamp
-from boss.api import fs, shell
+from boss.util import info, remote_info, remote_print, merge, localize_utc_timestamp
+from boss.api import fs, shell, runner
 
 LOCAL_BUILD_DIRECTORIES = ['build/', 'dist/']
 INITIAL_BUILD_HISTORY = {
@@ -353,3 +353,22 @@ def rollback(id=None):
 
     # TODO: Send rollback completed notification.
     remote_info('Rollback successful')
+
+
+def build(stage):
+    '''
+    Trigger build script to prepare a build for the given stage.
+    '''
+    info('Getting the build ready for deployment')
+
+    # Trigger the install script
+    runner.run_script(constants.SCRIPT_INSTALL, remote=False)
+
+    # Trigger the build script.
+    #
+    # The stage for which the build script is being run is passed
+    # via an environment variable STAGE.
+    # This could be useful for creating specific builds for
+    # different environments.
+    with shell_env(STAGE=stage):
+        runner.run_script(constants.SCRIPT_BUILD, remote=False)

--- a/boss/api/deployment/preset/node.py
+++ b/boss/api/deployment/preset/node.py
@@ -9,7 +9,7 @@ is started on restarted on the remote server.
 
 from datetime import datetime
 
-from fabric.api import task, cd, shell_env
+from fabric.api import task, cd
 
 from boss import constants
 from boss.util import info, remote_info, halt
@@ -98,19 +98,7 @@ def deploy():
     release_path = release_dir + '/' + build_name
     dist_path = build_name + '/dist'
 
-    info('Getting the build ready for deployment')
-
-    # Trigger the install script
-    runner.run_script(constants.SCRIPT_INSTALL, remote=False)
-
-    # Trigger the build script.
-    #
-    # The stage for which the build script is being run is passed
-    # via an environment variable STAGE.
-    # This could be useful for creating specific builds for
-    # different environments.
-    with shell_env(STAGE=stage):
-        runner.run_script(constants.SCRIPT_BUILD, remote=False)
+    buildman.build(stage)
 
     info('Compressing the build')
     fs.tar_archive(build_compressed, build_dir, remote=False)

--- a/boss/api/deployment/preset/node.py
+++ b/boss/api/deployment/preset/node.py
@@ -98,7 +98,7 @@ def deploy():
     release_path = release_dir + '/' + build_name
     dist_path = build_name + '/dist'
 
-    buildman.build(stage)
+    buildman.build(stage, config)
 
     info('Compressing the build')
     fs.tar_archive(build_compressed, build_dir, remote=False)

--- a/boss/api/deployment/preset/web.py
+++ b/boss/api/deployment/preset/web.py
@@ -13,7 +13,7 @@ from fabric.api import task, cd
 
 from boss.util import info, remote_info
 from boss.api import shell, notif, fs, git
-from boss.config import get_stage_config
+from boss.config import get_stage_config, get as get_config
 from boss.core.constants.notification import (
     DEPLOYMENT_STARTED,
     DEPLOYMENT_FINISHED
@@ -50,6 +50,7 @@ def setup():
 @task
 def deploy():
     ''' Zero-Downtime deployment for the web. '''
+    config = get_config()
     stage = shell.get_stage()
     user = get_stage_config(stage)['user']
 
@@ -83,7 +84,7 @@ def deploy():
     build_compressed = build_name + '.tar.gz'
     release_path = release_dir + '/' + build_name
 
-    buildman.build(stage)
+    buildman.build(stage, config)
 
     info('Compressing the build')
     fs.tar_archive(build_compressed, build_dir, remote=False)

--- a/boss/api/deployment/preset/web.py
+++ b/boss/api/deployment/preset/web.py
@@ -9,11 +9,10 @@ The source code is built locally and only the dist is uploaded and deployed to t
 
 from datetime import datetime
 
-from fabric.api import task, cd, shell_env
+from fabric.api import task, cd
 
-from boss import constants
 from boss.util import info, remote_info
-from boss.api import shell, notif, runner, fs, git
+from boss.api import shell, notif, fs, git
 from boss.config import get_stage_config
 from boss.core.constants.notification import (
     DEPLOYMENT_STARTED,
@@ -84,19 +83,7 @@ def deploy():
     build_compressed = build_name + '.tar.gz'
     release_path = release_dir + '/' + build_name
 
-    info('Getting the build ready for deployment')
-
-    # Trigger the install script
-    runner.run_script(constants.SCRIPT_INSTALL, remote=False)
-
-    # Trigger the build script.
-    #
-    # The stage for which the build script is being run is passed
-    # via an environment variable STAGE.
-    # This could be useful for creating specific builds for
-    # different environments.
-    with shell_env(STAGE=stage):
-        runner.run_script(constants.SCRIPT_BUILD, remote=False)
+    buildman.build(stage)
 
     info('Compressing the build')
     fs.tar_archive(build_compressed, build_dir, remote=False)

--- a/boss/config.py
+++ b/boss/config.py
@@ -113,8 +113,9 @@ def get_base_config(resolved_config=None):
         'port': config.get('port'),
         'branch': config.get('branch'),
         'app_dir': config.get('app_dir'),
+        'deployment': config.get('deployment'),
         'repository_url': config.get('repository_url'),
-        'deployment': config.get('deployment')
+        'remove_env_path': config.get('remove_env_path')
     }
 
 

--- a/boss/config.py
+++ b/boss/config.py
@@ -115,7 +115,7 @@ def get_base_config(resolved_config=None):
         'app_dir': config.get('app_dir'),
         'deployment': config.get('deployment'),
         'repository_url': config.get('repository_url'),
-        'remove_env_path': config.get('remove_env_path')
+        'remote_env_path': config.get('remote_env_path')
     }
 
 

--- a/boss/constants.py
+++ b/boss/constants.py
@@ -28,6 +28,7 @@ DEFAULT_CONFIG = {
     'project_name': 'untitled',
     'project_description': '',
     'branch_url': '{repository_url}/branch/{branch}',
+    'remote_env_injection': False,
     'stages': {},
     'scripts': {},
     'ci': {

--- a/boss/constants.py
+++ b/boss/constants.py
@@ -29,7 +29,7 @@ DEFAULT_CONFIG = {
     'project_description': '',
     'branch_url': '{repository_url}/branch/{branch}',
     'remote_env_injection': False,
-    'remove_env_path': None,
+    'remote_env_path': None,
     'stages': {},
     'scripts': {},
     'ci': {

--- a/boss/constants.py
+++ b/boss/constants.py
@@ -29,6 +29,7 @@ DEFAULT_CONFIG = {
     'project_description': '',
     'branch_url': '{repository_url}/branch/{branch}',
     'remote_env_injection': False,
+    'remove_env_path': None,
     'stages': {},
     'scripts': {},
     'ci': {

--- a/boss/core/env.py
+++ b/boss/core/env.py
@@ -1,0 +1,35 @@
+''' Utility for parsing env declarations. '''
+
+import codecs
+
+__escape_decoder = codecs.getdecoder('unicode_escape')
+
+
+def parse(env_def):
+    ''' Parse env variable definations. '''
+    result = {}
+
+    for line in env_def.splitlines():
+        line = line.strip()
+
+        if not line or line.startswith('#') or '=' not in line:
+            continue
+
+        k, v = line.split('=', 1)
+
+        # Remove any leading and trailing spaces in key, value
+        k, v = k.strip(), v.strip().encode('unicode-escape').decode('ascii')
+
+        if len(v) > 0:
+            quoted = v[0] == v[len(v) - 1] in ['"', "'"]
+
+            if quoted:
+                v = decode_escaped(v[1:-1])
+
+        result[k] = v
+
+    return result
+
+
+def decode_escaped(escaped):
+    return __escape_decoder(escaped)[0]

--- a/boss/core/env.py
+++ b/boss/core/env.py
@@ -1,12 +1,13 @@
 ''' Utility for parsing env declarations. '''
 
 import codecs
+from .util.string import is_quoted
 
 __escape_decoder = codecs.getdecoder('unicode_escape')
 
 
 def parse(env_def):
-    ''' Parse env variable definations. '''
+    ''' Parse env variable definitions. '''
     result = {}
 
     for line in env_def.splitlines():
@@ -15,18 +16,15 @@ def parse(env_def):
         if not line or line.startswith('#') or '=' not in line:
             continue
 
-        k, v = line.split('=', 1)
+        key, value = line.split('=', 1)
 
         # Remove any leading and trailing spaces in key, value
-        k, v = k.strip(), v.strip().encode('unicode-escape').decode('ascii')
+        key, value = key.strip(), value.strip().encode('unicode-escape').decode('ascii')
 
-        if len(v) > 0:
-            quoted = v[0] == v[len(v) - 1] in ['"', "'"]
+        if is_quoted(value):
+            value = decode_escaped(value[1:-1])
 
-            if quoted:
-                v = decode_escaped(v[1:-1])
-
-        result[k] = v
+        result[key] = value
 
     return result
 

--- a/boss/core/util/string.py
+++ b/boss/core/util/string.py
@@ -8,3 +8,12 @@ ANSI_CODES_REGEX = '\x1b[^m]*m'
 def strip_ansi(text):
     ''' Strip ANSI escape character codes from a string. '''
     return re.sub(ANSI_CODES_REGEX, '', text)
+
+
+def is_quoted(string):
+    ''' Check if the provided string is quoted. '''
+    return (
+        len(string) > 0 and
+        string[0] == string[-1] and
+        string[0] in ['"', "'"]
+    )

--- a/tests/core/test_env.py
+++ b/tests/core/test_env.py
@@ -1,0 +1,53 @@
+''' Tests for boss.core.env module '''
+
+from boss.core import env
+
+ENV_DEF_SIMPLE = '''
+NODE_ENV=development
+APP_PORT=3000
+APP_BASE_URL=http://localhost:3000
+'''
+
+ENV_DEF_WITH_INDENTATION = '''
+    VAR1=development
+    VAR2=3000
+'''
+
+ENV_DEF_WITH_COMMENTS = '''
+NODE_ENV=development
+# APP_PORT=3000
+#APP_BASE_URL=http://localhost:3000
+# This is just a test
+
+ANOTHER_VAR=Foo Bar
+'''
+
+ENV_DEF_WITH_QUOTED_VALUES = '''
+VAR1="Foo"
+VAR2='Bar'
+'''
+
+
+def test_parse_simple_env_def():
+    ''' Test it parses a simple env declaration. '''
+    result = env.parse(ENV_DEF_SIMPLE)
+
+    assert result['NODE_ENV'] == 'development'
+    assert result['APP_PORT'] == '3000'
+    assert result['APP_BASE_URL'] == 'http://localhost:3000'
+
+
+def test_parse_env_def_with_indentation():
+    ''' Test it parses a simple env declaration. '''
+    result = env.parse(ENV_DEF_WITH_INDENTATION)
+
+    assert result['VAR1'] == 'development'
+    assert result['VAR2'] == '3000'
+
+
+def test_parse_env_def_with_quoted_values():
+    ''' Test it parses a simple env declaration. '''
+    result = env.parse(ENV_DEF_WITH_QUOTED_VALUES)
+
+    assert result['VAR1'] == 'Foo'
+    assert result['VAR2'] == 'Bar'

--- a/tests/core/util/test_string.py
+++ b/tests/core/util/test_string.py
@@ -1,7 +1,7 @@
 ''' Unit tests for boss.core.util.string module. '''
 
 
-from boss.core.util.string import strip_ansi
+from boss.core.util.string import strip_ansi, is_quoted
 from fabric.colors import red
 
 
@@ -10,3 +10,17 @@ def test_strip_ansi():
     plain_text = 'This is just a test.'
 
     assert plain_text == strip_ansi(text)
+
+
+def test_is_quoted():
+    '''
+    Test is_quoted returns True only
+    for the quoted string values.
+    '''
+    assert is_quoted('"Hello World"') is True
+    assert is_quoted('\'Hello World\'') is True
+    assert is_quoted('Hello World') is False
+    assert is_quoted('\'Hello World') is False
+    assert is_quoted('"Hello World') is False
+    assert is_quoted('Hello World"') is False
+    assert is_quoted('Hello World\'') is False

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -91,12 +91,14 @@ def test_merge_config_base_config_is_merged_to_each_stage_specfic_config():
     '''
     raw_config = {
         'port': '1234',
+        'remote_env_path': 'test',
         'deployment': {
             'base_dir': '~/some/directory'
         },
         'stages': {
             'stage1': {
-                'host': 'stage1.example.com'
+                'host': 'stage1.example.com',
+                'remote_env_path': 'best'
             },
             'stage2': {
                 'host': 'stage2.example.com',
@@ -110,6 +112,7 @@ def test_merge_config_base_config_is_merged_to_each_stage_specfic_config():
     stage1_config = result['stages']['stage1']
     assert stage1_config['port'] == raw_config['port']
     assert stage1_config['host'] == raw_config['stages']['stage1']['host']
+    assert stage1_config['remote_env_path'] == raw_config['stages']['stage1']['remote_env_path']
     assert stage1_config['deployment'][
         'base_dir'] == raw_config['deployment']['base_dir']
     assert stage1_config['deployment'][
@@ -119,6 +122,7 @@ def test_merge_config_base_config_is_merged_to_each_stage_specfic_config():
     stage2_config = result['stages']['stage2']
     assert stage2_config['port'] == raw_config['stages']['stage2']['port']
     assert stage2_config['host'] == raw_config['stages']['stage2']['host']
+    assert stage2_config['remote_env_path'] == raw_config['remote_env_path']
     assert stage2_config['deployment'][
         'base_dir'] == raw_config['deployment']['base_dir']
     assert stage2_config['deployment'][


### PR DESCRIPTION
## Remote Environment Variables Injection
* Load environment variables from a remote host file.
* Inject the remote environment variables into the local build during deployment or while running any tasks.
* Have a `remove_env_path` stage-specfic config option which determines from which file on the remote host to load the env variables (default `None`).
* Have a configuration option `remote_env_injection` to enable this (default `False`).

Fixes #89 