### PR TITLE
Fix weird `<pre>` tag hipchat notifcation issue 

### DIFF
--- a/boss/api/hipchat.py
+++ b/boss/api/hipchat.py
@@ -24,7 +24,6 @@ def send(notif_type, **params):
         config=get_config(),
         notif_config=config(),
         create_link=create_link,
-        pre_format=pre_format,
         **params
     )
 
@@ -53,8 +52,3 @@ def create_link(url, title):
     markup = '<a href="{url}">{title}</a>'
 
     return markup.format(url=url, title=title)
-
-
-def pre_format(text):
-    ''' Return pre-formatted text for hipchat. '''
-    return '<pre>{text}</pre>'.format(text=text)

--- a/tests/api/test_hipchat.py
+++ b/tests/api/test_hipchat.py
@@ -156,7 +156,7 @@ def test_send_running_script_started_notification(base_url):
         'color': 'green',
         'notify': True,
         'message_format': 'html',
-        'message': 'user is running <pre>migration</pre> for <a href="http://repository-url">project-name</a> on <a href="http://public-url">stage</a> server.'
+        'message': 'user is running migration for <a href="http://repository-url">project-name</a> on <a href="http://public-url">stage</a> server.'
     }
 
     with patch('requests.post') as mock_post:
@@ -181,7 +181,7 @@ def test_send_running_script_finished_notification(base_url):
         'color': 'purple',
         'notify': True,
         'message_format': 'html',
-        'message': 'user finished running <pre>migration</pre> for <a href="http://repository-url">project-name</a> on <a href="http://public-url">stage</a> server.'
+        'message': 'user finished running migration for <a href="http://repository-url">project-name</a> on <a href="http://public-url">stage</a> server.'
     }
 
     with patch('requests.post') as mock_post:


### PR DESCRIPTION
* Avoid formatting the script name with `<pre>` tag for hipchat notifications.