### PR TITLE
Resolve remote cwd and normalize remote paths correctly

### DIFF
--- a/boss/api/ssh.py
+++ b/boss/api/ssh.py
@@ -59,10 +59,34 @@ def resolve_sftp_client():
         return sftp_connections[host_string]
 
     # Open a new SFTP connection and put in on the state.
-    sftp = state.get('connections')[host_string].open_sftp()
+    ssh_client = state.get('connections')[host_string]
+    sftp = ssh_client.open_sftp()
     sftp_connections.update({host_string: sftp})
 
     return sftp
+
+
+def resolve_cwd(host_string):
+    '''
+    Resolve current working directory of the remote host.
+
+    TODO: After refactor resolve cwd at the very begining,
+    instead of every time before any operation.
+    '''
+    remote_state = state.get('remote')
+
+    if not remote_state.get(host_string):
+        remote_state[host_string] = {}
+
+    remote_host_state = remote_state.get(host_string)
+
+    if not remote_host_state.get('cwd'):
+        cwd = remote.cwd(resolve_client())
+        remote_host_state['cwd'] = cwd
+
+        return cwd
+
+    return remote_host_state.get('cwd')
 
 
 def put(local_path, remote_path, callback=None):

--- a/boss/api/ssh.py
+++ b/boss/api/ssh.py
@@ -37,6 +37,20 @@ def run(command, **params):
         pass
 
 
+def normalize_path(remote_path):
+    '''
+    Normalize remote path.
+    Expand home directory '~' in the path if it exists.
+    '''
+    home = resolve_cwd()
+
+    # Expand home directory markers (tildes, etc)
+    if remote_path.startswith('~'):
+        remote_path = remote_path.replace('~', home)
+
+    return remote_path
+
+
 def resolve_client():
     '''
     Resolves already opened SSHClient connection.
@@ -59,14 +73,13 @@ def resolve_sftp_client():
         return sftp_connections[host_string]
 
     # Open a new SFTP connection and put in on the state.
-    ssh_client = state.get('connections')[host_string]
-    sftp = ssh_client.open_sftp()
+    sftp = resolve_client().open_sftp()
     sftp_connections.update({host_string: sftp})
 
     return sftp
 
 
-def resolve_cwd(host_string):
+def resolve_cwd():
     '''
     Resolve current working directory of the remote host.
 
@@ -74,6 +87,7 @@ def resolve_cwd(host_string):
     instead of every time before any operation.
     '''
     remote_state = state.get('remote')
+    host_string = state.get('env').host_string
 
     if not remote_state.get(host_string):
         remote_state[host_string] = {}
@@ -94,6 +108,7 @@ def put(local_path, remote_path, callback=None):
     Transfers a local file to the remote path via SFTP (Paramiko).
     '''
     sftp = resolve_sftp_client()
+    remote_path = normalize_path(remote_path)
 
     # Do the put operation.
     return remote.put(
@@ -109,6 +124,7 @@ def get(local_path, remote_path, callback=None):
     Transfers a remote file to local path via SFTP (Paramiko).
     '''
     sftp = resolve_sftp_client()
+    remote_path = normalize_path(remote_path)
 
     # Do the get operation.
     return remote.get(
@@ -125,6 +141,7 @@ def read(remote_path, callback=None):
     and return it's contents as string.
     '''
     sftp = resolve_sftp_client()
+    remote_path = normalize_path(remote_path)
 
     return remote.read(sftp, remote_path, callback)
 
@@ -134,6 +151,7 @@ def write(remote_path, data, **params):
     Write data to a remote file on the remote host.
     '''
     sftp = resolve_sftp_client()
+    remote_path = normalize_path(remote_path)
 
     return remote.write(
         sftp,

--- a/boss/core/remote.py
+++ b/boss/core/remote.py
@@ -65,6 +65,13 @@ def run(client, command, **params):
     return client.exec_command(command, **known_params)
 
 
+def cwd(client):
+    ''' Get current working directory of remote host. '''
+    (_, stdout, _) = run(client, 'pwd')
+
+    return stdout.read().strip()
+
+
 def read(client, remote_path, callback=None):
     '''
     Read a remote file given by the path on the remote host

--- a/boss/core/remote.py
+++ b/boss/core/remote.py
@@ -6,20 +6,9 @@ This is an abstraction over the underlying SSH/SFTP transport
 which uses paramiko directly for remote execution and transfers.
 '''
 
-import os
 from StringIO import StringIO
 
 from boss.core.util.object import with_only
-
-
-def normalize_path(sftp_client, remote_path):
-    home = sftp_client.normalize('.')
-
-    # Expand home directory markers (tildes, etc)
-    if remote_path.startswith('~'):
-        remote_path = os.path.join(home, remote_path.replace('~', ''))
-
-    return remote_path
 
 
 def put(sftp_client, **params):
@@ -28,7 +17,7 @@ def put(sftp_client, **params):
     '''
 
     local_path = params['local_path']
-    remote_path = normalize_path(sftp_client, params['remote_path'])
+    remote_path = params['remote_path']
     callback = params.get('callback')
     confirm = params.get('confirm')
 
@@ -40,7 +29,7 @@ def get(sftp_client, **params):
     Transfers (download) a remote file to the local path via SFTP.
     '''
 
-    remote_path = normalize_path(sftp_client, params['remote_path'])
+    remote_path = params['remote_path']
     local_path = params['local_path']
     callback = params.get('callback')
 

--- a/boss/state.py
+++ b/boss/state.py
@@ -4,7 +4,8 @@ from copy import deepcopy
 
 
 _state = {
-    'sftp_connections': {}
+    'sftp_connections': {},
+    'remote': {}
 }
 
 

--- a/tests/integration/test_buildman_integration.py
+++ b/tests/integration/test_buildman_integration.py
@@ -24,8 +24,8 @@ def test_load_history(server):
             with patch('boss.api.deployment.buildman.get_builds_file') as gbf_m:
                 gbf_m.return_value = path
 
-                with patch('boss.api.ssh.resolve_sftp_client') as rsc_m:
-                    rsc_m.return_value = client.open_sftp()
+                with patch('boss.api.ssh.resolve_client') as rc_m:
+                    rc_m.return_value = client
                     result = buildman.load_history()
 
                     assert result['foo'] == 'bar'
@@ -44,8 +44,8 @@ def test_save_history(server):
             with patch('boss.api.deployment.buildman.get_builds_file') as gbf_m:
                 gbf_m.return_value = path
 
-                with patch('boss.api.ssh.resolve_sftp_client') as rsc_m:
-                    rsc_m.return_value = client.open_sftp()
+                with patch('boss.api.ssh.resolve_client') as rc_m:
+                    rc_m.return_value = client
                     buildman.save_history({
                         'foo': 'bar',
                         'hello': 'world'
@@ -66,8 +66,8 @@ def test_load_remote_env_vars(server):
         fs.write(path, REMOTE_ENV_FILE)
 
         with server.client(uid) as client:
-            with patch('boss.api.ssh.resolve_sftp_client') as rsc_m:
-                rsc_m.return_value = client.open_sftp()
+            with patch('boss.api.ssh.resolve_client') as rc_m:
+                rc_m.return_value = client
                 result = buildman.load_remote_env_vars(path)
 
                 assert result['FOO'] == 'bar'

--- a/tests/integration/test_remote_integration.py
+++ b/tests/integration/test_remote_integration.py
@@ -95,3 +95,13 @@ def test_write_overwrites_existing_file(server):
             remote.write(sftp, path, data='Hello World!')
 
             assert fs.read(path) == 'Hello World!'
+
+
+def test_cwd(server):
+    ''' Test cwd() returns remote current. '''
+    for uid in server.users:
+        with server.client(uid) as client:
+            cwd = remote.cwd(client)
+
+            assert cwd is not None
+            assert fs.exists(cwd)


### PR DESCRIPTION
* Introduce `remote.cwd` function to get current working directory of the remote.
* Normalize remote paths (with home directory `~`)  correctly.