### PR TITLE
Normalize remote path while invoking ssh.upload_dir()

### DIFF
--- a/boss/api/ssh.py
+++ b/boss/api/ssh.py
@@ -173,6 +173,7 @@ def upload_dir(local_path, remote_path, callback=None):
     tmp_folder = mkdtemp()
     tar_filename = os.path.basename(local_path) + '.tar.gz'
     tar_path = os.path.join(tmp_folder, tar_filename)
+    remote_path = normalize_path(remote_path)
 
     # Compress the directory.
     compress(local_path, tar_path)

--- a/tests/integration/test_ssh_integration.py
+++ b/tests/integration/test_ssh_integration.py
@@ -40,3 +40,46 @@ def test_upload_dir(server):
                 assert fs.exists(os.path.join(remote_path, 'b'))
                 assert fs.read(os.path.join(remote_path, 'a/foo.txt')) == 'Foo'
                 assert fs.read(os.path.join(remote_path, 'b/bar.txt')) == 'Bar'
+
+
+def test_upload_dir_with_home_directory(server):
+    '''
+    Test upload_dir() transfers a local directory to the remote end,
+    when remote_path includes home directory `~`.
+    '''
+
+    # Setup local directory.
+    local_dir = os.path.join(mkdtemp(), 'test2')
+
+    os.mkdir(local_dir)
+    os.mkdir(os.path.join(local_dir, 'a'))
+    os.mkdir(os.path.join(local_dir, 'b'))
+
+    fs.write(os.path.join(local_dir, 'a/foo.txt'), 'Foo')
+    fs.write(os.path.join(local_dir, 'b/bar.txt'), 'Bar')
+
+    for uid in server.users:
+        remote_path = '~/deployment'
+
+        with server.client(uid) as client:
+            with patch('boss.api.ssh.resolve_client') as rc_m:
+                rc_m.return_value = client
+                with patch('boss.api.ssh.resolve_cwd') as rcwd_m:
+                    rcwd_m.return_value = server.ROOT_DIR
+
+                    expanded_remote_path = os.path.join(
+                        server.ROOT_DIR, 'deployment')
+
+                    assert not fs.exists(expanded_remote_path)
+
+                    # Upload the directory
+                    upload_dir(local_dir, remote_path)
+
+                    # Test the whole directory got uploaded with all files
+                    assert fs.exists(expanded_remote_path)
+                    assert fs.exists(os.path.join(expanded_remote_path, 'a'))
+                    assert fs.exists(os.path.join(expanded_remote_path, 'b'))
+                    assert fs.read(os.path.join(
+                        expanded_remote_path, 'a/foo.txt')) == 'Foo'
+                    assert fs.read(os.path.join(
+                        expanded_remote_path, 'b/bar.txt')) == 'Bar'


### PR DESCRIPTION
### Changes
* Normalize remote path on `ssh.upload_dir()` to make sure remote paths with `~` are expanded.
* Integration test to ensure `upload_dir()` transfers a local directory to the remote end, when remote_path includes home directory `~`.

### Accomplishments
And finally 100 tests passed so far :100: :boom:.
![image](https://user-images.githubusercontent.com/3315763/34460701-289c7d98-ee3e-11e7-8337-888b1baf4d11.png)

