### PR TITLE
Ignore notification failure, and proceed even if sending notification fails 

### DIFF
--- a/boss/api/fs.py
+++ b/boss/api/fs.py
@@ -1,6 +1,5 @@
-''' File System utilities API. '''
+''' File System utilities over SSH for the Remote end. '''
 
-import os
 import time
 
 from boss.api import ssh
@@ -21,14 +20,13 @@ def mkdir(path, nested=False):
     ssh.run(cmd)
 
 
-def rm(path, remote=True):
+def rm(path):
     ''' Remove a file given by the path. '''
-    ssh.run('rm ' + path, remote=remote)
+    ssh.run('rm ' + path)
 
 
 def rm_rf(path):
     ''' Remote the specified path recursively (both files and directories). '''
-
     removal_path = path
 
     # If path is not a string but a list of multiple paths,
@@ -67,16 +65,11 @@ def glob(path):
     return ssh.run('ls -1 {}'.format(path))
 
 
-def exists(path, remote=True):
+def exists(path):
     '''
-    Check if the path exists in the remote or locally,
-    depending upon the `remote` parameter.
+    Check if the path exists in the remote.
     '''
-
-    if remote:
-        return ssh.exists(path)
-
-    return os.path.exists(path)
+    return ssh.exists(path)
 
 
 def upload(local_path, remote_path):

--- a/boss/api/notif.py
+++ b/boss/api/notif.py
@@ -2,9 +2,9 @@
 Notification API module.
 '''
 
-from ..util import remote_info
-from . import slack, hipchat, git
-from ..config import get_stage_config, get as get_config
+from boss.core.output import warn
+from boss.api import slack, hipchat, git
+from boss.config import get_stage_config, get as get_config
 
 # Notification Services
 notifiers = [slack, hipchat]
@@ -19,11 +19,15 @@ def send(notif_type, params):
     if not enabled_services:
         return
 
-    remote_info('Sending notifications')
     notif_params = extract_notification_params(params)
 
-    for service in enabled_services:
-        service.send(notif_type, **notif_params)
+    try:
+        for service in enabled_services:
+            service.send(notif_type, **notif_params)
+    except:
+        # Should still proceed if error sending notification,
+        # printing an warning message.
+        warn('Warning: Failed sending notifications.')
 
 
 def extract_notification_params(params):

--- a/boss/api/ssh.py
+++ b/boss/api/ssh.py
@@ -222,6 +222,7 @@ def exists(path):
     Check if the remote path exists.
     '''
     try:
+        path = normalize_path(path)
         stat(path)
         return True
     except IOError:
@@ -234,6 +235,7 @@ def is_dir(path):
     TODO: Move this to a remote fs module.
     '''
     try:
+        path = normalize_path(path)
         mode = stat(path).st_mode
 
         return S_ISDIR(mode)

--- a/tests/api/test_notif.py
+++ b/tests/api/test_notif.py
@@ -9,12 +9,11 @@ from boss.core.constants.notification_types import (
 )
 
 
-@patch('boss.api.notif.remote_info')
 @patch('boss.api.notif.get_config')
 @patch('boss.api.notif.get_stage_config')
 @patch('boss.api.slack.is_enabled')
 @patch('boss.api.slack.send')
-def test_notif_sends_slack_notification(slack_send_m, slack_is_enabled_m, gsc_m, get_m, _):
+def test_notif_sends_slack_notification(slack_send_m, slack_is_enabled_m, gsc_m, get_m):
     ''' Test notif.send sends slack notification if slack is enabled. '''
     commit = 't12345'
     commit_url = 'https://github.com/kabirbaidhya/boss/tree/t12345'
@@ -72,12 +71,11 @@ def test_notif_sends_slack_notification(slack_send_m, slack_is_enabled_m, gsc_m,
     assert call2[1]['user'] == 'ssh-user'
 
 
-@patch('boss.api.notif.remote_info')
 @patch('boss.api.notif.get_config')
 @patch('boss.api.notif.get_stage_config')
 @patch('boss.api.hipchat.is_enabled')
 @patch('boss.api.hipchat.send')
-def test_notif_sends_hipchat_notification(hipchat_send_m, hipchat_is_enabled_m, gsc_m, get_m, _):
+def test_notif_sends_hipchat_notification(hipchat_send_m, hipchat_is_enabled_m, gsc_m, get_m):
     ''' Test notif.send sends hipchat notification if hipchat is enabled. '''
     commit = 't12345'
     commit_url = 'https://github.com/kabirbaidhya/boss/tree/t12345'


### PR DESCRIPTION
* Do not halt if sending notification fails, show a warning instead and proceed.
* Normalize new ssh functions
* Remove unnecessary args from fs util functions