### PR TITLE
Support running a list of commands with ssh.run() function

### DIFF
--- a/boss/api/ssh.py
+++ b/boss/api/ssh.py
@@ -8,16 +8,22 @@ from stat import S_ISDIR
 from boss import state
 from boss.core import remote
 from boss.core.fs import compress
+from boss.core.util.types import is_string, is_iterable
 
 
 def run(command, **params):
     '''
-    Execute a command on the remote host over SSH.
+    Execute a command or a list of commands on the remote host over SSH.
     '''
 
     # Keyword args
     raw = params.get('raw') or False
     return_output = params.get('return_output') or True
+
+    # If command is a list of commands,
+    # concat the commands and run them all.
+    if not is_string(command) and is_iterable(command):
+        command = '; '.join(command)
 
     # Execute the command and get the IO streams.
     (stdin, stdout, stderr) = remote.run(resolve_client(), command, **params)

--- a/tests/integration/test_ssh_integration.py
+++ b/tests/integration/test_ssh_integration.py
@@ -111,3 +111,30 @@ def test_put_when_remote_directory_provided(server):
 
                 assert fs.exists(expected_target_file)
                 assert fs.read(expected_target_file) == 'Test put operation'
+
+
+def test_run(server):
+    ''' Test run() executes a command over ssh. '''
+    for uid in server.users:
+        with server.client(uid) as client:
+            with patch('boss.api.ssh.resolve_client') as rc_m:
+                rc_m.return_value = client
+                result = ssh.run('echo "hello"')
+
+                assert 'hello' in result
+
+
+def test_run_list_of_commands(server):
+    ''' Test run() executes a series of commands over ssh. '''
+    for uid in server.users:
+        with server.client(uid) as client:
+            with patch('boss.api.ssh.resolve_client') as rc_m:
+                rc_m.return_value = client
+                result = ssh.run([
+                    'echo "hello"',
+                    'echo "world"',
+                    'echo "foo"',
+                    'echo "bar"'
+                ])
+
+                assert result == ['hello', 'world', 'foo', 'bar']


### PR DESCRIPTION
`ssh.run()` supports both of these cases now:
 * Running a single command.
    ```python
    ssh.run('pm2 reload')
    ```
 * Running multiple commands over a single ssh session.
    ```python
    ssh.run([
      'cd /path/to/project',
      'pm2 reload'
    ])
    ```
