### PR TITLE
Fix provided branch being ignored on the remote-source deployment

### DIFF
--- a/boss/api/deployment/preset/remote_source.py
+++ b/boss/api/deployment/preset/remote_source.py
@@ -23,7 +23,7 @@ def deploy(branch=None):
     ''' Deploy to remote source. '''
     stage = shell.get_stage()
     deployer_user = shell.get_user()
-    branch = get_stage_config(stage)['branch']
+    branch = branch or get_stage_config(stage)['branch']
     commit = git.last_commit(short=True)
     notif.send(notification_types.DEPLOYMENT_STARTED, {
         'user': deployer_user,


### PR DESCRIPTION
* The provided deployment `branch` on deployment was being ignored always taking the default branch for that stage on `remote-source` deployment. **Fixed**.