### PR TITLE
Support flexible notification messages

### DIFF
--- a/boss/api/git.py
+++ b/boss/api/git.py
@@ -62,7 +62,7 @@ def get_commit_url(commit, repository_url=None):
     return '{repository_url}/commit/{commit}'.format(
         repository_url=repository_url,
         commit=commit
-    ) if repository_url else commit
+    ) if repository_url else None
 
 
 def get_tree_url(ref, repository_url=None):
@@ -70,7 +70,7 @@ def get_tree_url(ref, repository_url=None):
     return '{repository_url}/tree/{ref}'.format(
         repository_url=repository_url,
         ref=ref
-    ) if repository_url else ref
+    ) if repository_url else None
 
 
 def show_last_commit():

--- a/boss/api/git.py
+++ b/boss/api/git.py
@@ -56,21 +56,21 @@ def current_branch(remote=True):
         return result.strip()
 
 
-def get_commit_url(commit, repository_url):
+def get_commit_url(commit, repository_url=None):
     ''' Get a link for a commit for GitHub. '''
     # TODO: Make it independent of GitHub.
     return '{repository_url}/commit/{commit}'.format(
         repository_url=repository_url,
         commit=commit
-    )
+    ) if repository_url else commit
 
 
-def get_tree_url(ref, repository_url):
+def get_tree_url(ref, repository_url=None):
     ''' Get a link for a ref (commit, branch or tag) for the repository. '''
     return '{repository_url}/tree/{ref}'.format(
         repository_url=repository_url,
         ref=ref
-    )
+    ) if repository_url else ref
 
 
 def show_last_commit():

--- a/boss/api/hipchat.py
+++ b/boss/api/hipchat.py
@@ -49,6 +49,9 @@ def is_enabled():
 
 def create_link(url, title):
     ''' Create a link for hipchat payload. '''
+    if not url:
+        return title
+
     markup = '<a href="{url}">{title}</a>'
 
     return markup.format(url=url, title=title)

--- a/boss/api/notif.py
+++ b/boss/api/notif.py
@@ -34,13 +34,14 @@ def extract_notification_params(params):
     ''' Extract parameters for notification. '''
     config = get_config()
     stage_config = get_stage_config(params['stage'])
+    public_url = stage_config.get('public_url') or stage_config.get('host')
     repository_url = config.get('repository_url')
 
     notif_params = dict(
+        public_url=public_url,
+        repository_url=repository_url,
         host=stage_config['host'],
         server_name=params['stage'],
-        repository_url=repository_url,
-        public_url=stage_config['public_url'],
         project_name=config['project_name'],
         project_description=config['project_description'],
         **params

--- a/boss/api/notif.py
+++ b/boss/api/notif.py
@@ -34,12 +34,13 @@ def extract_notification_params(params):
     ''' Extract parameters for notification. '''
     config = get_config()
     stage_config = get_stage_config(params['stage'])
+    repository_url = config.get('repository_url')
 
     notif_params = dict(
         host=stage_config['host'],
         server_name=params['stage'],
+        repository_url=repository_url,
         public_url=stage_config['public_url'],
-        repository_url=config['repository_url'],
         project_name=config['project_name'],
         project_description=config['project_description'],
         **params
@@ -49,7 +50,7 @@ def extract_notification_params(params):
     if params.get('commit'):
         notif_params['commit_url'] = git.get_tree_url(
             params['commit'],
-            config['repository_url']
+            repository_url
         )
 
     # If branch is provided and branch is not HEAD, then add branch & branch_url.
@@ -61,7 +62,7 @@ def extract_notification_params(params):
         notif_params['branch'] = params['branch']
         notif_params['branch_url'] = git.get_tree_url(
             params['branch'],
-            config['repository_url']
+            repository_url
         )
     else:
         notif_params['branch'] = None

--- a/boss/api/notif.py
+++ b/boss/api/notif.py
@@ -34,7 +34,8 @@ def extract_notification_params(params):
     ''' Extract parameters for notification. '''
     config = get_config()
     stage_config = get_stage_config(params['stage'])
-    public_url = stage_config.get('public_url') or stage_config.get('host')
+    fallback_public_url = 'http://' + stage_config.get('host')
+    public_url = stage_config.get('public_url') or fallback_public_url
     repository_url = config.get('repository_url')
 
     notif_params = dict(

--- a/boss/api/slack.py
+++ b/boss/api/slack.py
@@ -45,6 +45,9 @@ def is_enabled():
 
 def create_link(url, title):
     ''' Create a link for slack payload. '''
+    if not url:
+        return title
+
     return '<{url}|{title}>'.format(
         url=url,
         title=title

--- a/boss/core/constants/notification.py
+++ b/boss/core/constants/notification.py
@@ -11,15 +11,19 @@ from .notification_types import (
 
 MESSAGE_MAP = {
     DEPLOYMENT_STARTED: {
-        'message': '{user} is deploying {project_link} ({commit_link}) to {server_link} server.',
-        'message_with_branch': '{user} is deploying {project_link}:{branch_link} ({commit_link}) to {server_link} server.',
+        'message': '{user} is deploying {project_link} to {server_link} server.',
+        'message_with_branch': '{user} is deploying {project_link}:{branch_link} to {server_link} server.',
+        'message_with_commit': '{user} is deploying {project_link} ({commit_link}) to {server_link} server.',
+        'message_full': '{user} is deploying {project_link}:{branch_link} ({commit_link}) to {server_link} server.',
         # TODO: Rename this to started_color & ci_started_color
         'color': 'deploying_color',
         'ci_color': 'ci_deploying_color'
     },
     DEPLOYMENT_FINISHED: {
-        'message': '{user} finished deploying {project_link} ({commit_link}) to {server_link} server.',
-        'message_with_branch': '{user} finished deploying {project_link}:{branch_link} ({commit_link}) to {server_link} server.',
+        'message': '{user} finished deploying {project_link} to {server_link} server.',
+        'message_with_branch': '{user} finished deploying {project_link}:{branch_link} to {server_link} server.',
+        'message_with_commit': '{user} finished deploying {project_link} ({commit_link}) to {server_link} server.',
+        'message_full': '{user} finished deploying {project_link}:{branch_link} ({commit_link}) to {server_link} server.',
         # TODO: Rename this to started_color & ci_started_color
         'color': 'deployed_color',
         'ci_color': 'ci_deployed_color'

--- a/boss/core/notification.py
+++ b/boss/core/notification.py
@@ -43,8 +43,12 @@ def get_message(notif_type, **notification):
 
     messages = MESSAGE_MAP[notif_type]
 
-    if notification.has_key('branch_link'):
+    if notification.has_key('branch_link') and notification.has_key('commit_link'):
+        text = messages['message_full'].format(**notification)
+    elif notification.has_key('branch_link'):
         text = messages['message_with_branch'].format(**notification)
+    elif notification.has_key('commit_link'):
+        text = messages['message_with_commit'].format(**notification)
     else:
         text = messages['message'].format(**notification)
 

--- a/boss/core/notification.py
+++ b/boss/core/notification.py
@@ -73,9 +73,10 @@ def get_notification_params(**params):
         params['project_name']
     )
 
-    if params.get('public_url') and params.get('server_name'):
+    if params.get('server_name'):
         result['server_link'] = create_link(
-            params['public_url'], params['server_name']
+            params.get('public_url'),
+            params['server_name']
         )
 
     if params.get('commit'):

--- a/boss/core/notification.py
+++ b/boss/core/notification.py
@@ -68,26 +68,25 @@ def get_notification_params(**params):
     create_link = params['create_link']
     result = dict(user=params['user'])
 
-    if params.get('repository_url') and params.get('project_name'):
-        result['project_link'] = create_link(
-            params['repository_url'],
-            params['project_name']
-        )
+    result['project_link'] = create_link(
+        params.get('repository_url'),
+        params['project_name']
+    )
 
     if params.get('public_url') and params.get('server_name'):
         result['server_link'] = create_link(
             params['public_url'], params['server_name']
         )
 
-    if params.get('commit_url') and params.get('commit'):
+    if params.get('commit'):
         result['commit_link'] = create_link(
-            params['commit_url'],
+            params.get('commit_url'),
             params['commit']
         )
 
-    if params.get('branch_url') and params.get('branch'):
+    if params.get('branch'):
         result['branch_link'] = create_link(
-            params['branch_url'],
+            params.get('branch_url'),
             params['branch']
         )
 

--- a/tests/api/test_git.py
+++ b/tests/api/test_git.py
@@ -15,3 +15,17 @@ def test_get_tree_url():
     url = get_tree_url('master', 'https://github.com/kabirbaidhya/boss')
 
     assert url == 'https://github.com/kabirbaidhya/boss/tree/master'
+
+
+def test_get_commit_url_when_no_repository_url():
+    ''' Test get_commit_url() returns the commit, if repository_url is not provided. '''
+    url = get_commit_url('f626609')
+
+    assert url == 'f626609'
+
+
+def test_get_tree_url_when_no_repository_url():
+    ''' Test get_tree_url() returns the ref, if repository_url is not provided. '''
+    url = get_tree_url('master')
+
+    assert url == 'master'

--- a/tests/api/test_git.py
+++ b/tests/api/test_git.py
@@ -1,0 +1,17 @@
+''' Tests for boss.api.git module. '''
+
+from boss.api.git import get_commit_url, get_tree_url
+
+
+def test_get_commit_url():
+    ''' Test get_commit_url(). '''
+    url = get_commit_url('f626609', 'https://github.com/kabirbaidhya/boss')
+
+    assert url == 'https://github.com/kabirbaidhya/boss/commit/f626609'
+
+
+def test_get_tree_url():
+    ''' Test get_tree_url(). '''
+    url = get_tree_url('master', 'https://github.com/kabirbaidhya/boss')
+
+    assert url == 'https://github.com/kabirbaidhya/boss/tree/master'

--- a/tests/api/test_git.py
+++ b/tests/api/test_git.py
@@ -21,11 +21,11 @@ def test_get_commit_url_when_no_repository_url():
     ''' Test get_commit_url() returns the commit, if repository_url is not provided. '''
     url = get_commit_url('f626609')
 
-    assert url == 'f626609'
+    assert url is None
 
 
 def test_get_tree_url_when_no_repository_url():
     ''' Test get_tree_url() returns the ref, if repository_url is not provided. '''
     url = get_tree_url('master')
 
-    assert url == 'master'
+    assert url is None

--- a/tests/api/test_hipchat.py
+++ b/tests/api/test_hipchat.py
@@ -83,6 +83,56 @@ def test_notity_deployed(base_url):
         mock_post.assert_called_once_with(base_url, json=payload)
 
 
+def test_notity_deployment_finished_with_no_commit(base_url):
+    ''' Test deployment finished notification with no commit. '''
+    notify_params = dict(
+        branch_url='http://branch-url',
+        branch='temp',
+        public_url='http://public-url',
+        host='test-notify-deploying-host',
+        repository_url='http://repository-url',
+        project_name='project-name',
+        server_name='stage',
+        server_link='http://server-link',
+        user='user',
+    )
+    payload = {
+        'color': 'purple',
+        'message': 'user finished deploying <a href="http://repository-url">project-name</a>:<a href="http://branch-url">temp</a> to <a href="http://public-url">stage</a> server.',
+        'notify': True,
+        'message_format': 'html'
+    }
+
+    with patch('requests.post') as mock_post:
+        hipchat.send(DEPLOYMENT_FINISHED, **notify_params)
+        mock_post.assert_called_once_with(base_url, json=payload)
+
+
+def test_notity_deployment_started_with_no_commit(base_url):
+    ''' Test deployment started notification with no commit. '''
+    notify_params = dict(
+        branch_url='http://branch-url',
+        branch='temp',
+        public_url='http://public-url',
+        host='test-notify-deploying-host',
+        repository_url='http://repository-url',
+        project_name='project-name',
+        server_name='stage',
+        server_link='http://server-link',
+        user='user',
+    )
+    payload = {
+        'color': 'green',
+        'message': 'user is deploying <a href="http://repository-url">project-name</a>:<a href="http://branch-url">temp</a> to <a href="http://public-url">stage</a> server.',
+        'notify': True,
+        'message_format': 'html'
+    }
+
+    with patch('requests.post') as mock_post:
+        hipchat.send(DEPLOYMENT_STARTED, **notify_params)
+        mock_post.assert_called_once_with(base_url, json=payload)
+
+
 def test_notity_deploying_with_no_branch(base_url):
     '''
     Test hipchat.notify_deploying() doesn't show branch link,

--- a/tests/api/test_hipchat.py
+++ b/tests/api/test_hipchat.py
@@ -189,6 +189,52 @@ def test_notity_deployed_with_no_branch(base_url):
         mock_post.assert_called_once_with(base_url, json=payload)
 
 
+def test_notity_deployment_finished_with_no_commit_no_branch(base_url):
+    ''' Test deployment finished notification with no commit and no branch. '''
+    notify_params = dict(
+        public_url='http://public-url',
+        host='test-notify-deploying-host',
+        repository_url='http://repository-url',
+        project_name='project-name',
+        server_name='stage',
+        server_link='http://server-link',
+        user='user',
+    )
+    payload = {
+        'color': 'purple',
+        'message': 'user finished deploying <a href="http://repository-url">project-name</a> to <a href="http://public-url">stage</a> server.',
+        'notify': True,
+        'message_format': 'html'
+    }
+
+    with patch('requests.post') as mock_post:
+        hipchat.send(DEPLOYMENT_FINISHED, **notify_params)
+        mock_post.assert_called_once_with(base_url, json=payload)
+
+
+def test_notity_deployment_started_with_no_commit_no_branch(base_url):
+    ''' Test deployment started notification with no commit and no branch. '''
+    notify_params = dict(
+        public_url='http://public-url',
+        host='test-notify-deploying-host',
+        repository_url='http://repository-url',
+        project_name='project-name',
+        server_name='stage',
+        server_link='http://server-link',
+        user='user',
+    )
+    payload = {
+        'color': 'green',
+        'message': 'user is deploying <a href="http://repository-url">project-name</a> to <a href="http://public-url">stage</a> server.',
+        'notify': True,
+        'message_format': 'html'
+    }
+
+    with patch('requests.post') as mock_post:
+        hipchat.send(DEPLOYMENT_STARTED, **notify_params)
+        mock_post.assert_called_once_with(base_url, json=payload)
+
+
 def test_send_running_script_started_notification(base_url):
     ''' Test send() sends RUNNING_SCRIPT_STARTED notfication. '''
     notify_params = dict(

--- a/tests/api/test_hipchat.py
+++ b/tests/api/test_hipchat.py
@@ -29,6 +29,11 @@ def test_create_link():
     assert hipchat.create_link(url, title) == expected_link
 
 
+def test_create_link_supports_empty_url():
+    ''' Test hipchat.create_link() supports empty url. '''
+    assert hipchat.create_link(None, 'Test') == 'Test'
+
+
 def test_notity_deploying(base_url):
     ''' Test hipchat.notify_deploying(). '''
     notify_params = dict(

--- a/tests/api/test_hipchat.py
+++ b/tests/api/test_hipchat.py
@@ -294,6 +294,25 @@ def test_notity_deployment_started_with_no_commit_no_branch(base_url):
         mock_post.assert_called_once_with(base_url, json=payload)
 
 
+def test_notity_deployment_started_no_links_at_all(base_url):
+    ''' Test deployment started notification with no links or urls at all. '''
+    notify_params = dict(
+        project_name='project-name',
+        server_name='staging',
+        user='user',
+    )
+    payload = {
+        'color': 'green',
+        'message': 'user is deploying project-name to staging server.',
+        'notify': True,
+        'message_format': 'html'
+    }
+
+    with patch('requests.post') as mock_post:
+        hipchat.send(DEPLOYMENT_STARTED, **notify_params)
+        mock_post.assert_called_once_with(base_url, json=payload)
+
+
 def test_send_running_script_started_notification(base_url):
     ''' Test send() sends RUNNING_SCRIPT_STARTED notfication. '''
     notify_params = dict(

--- a/tests/api/test_hipchat.py
+++ b/tests/api/test_hipchat.py
@@ -88,6 +88,60 @@ def test_notity_deployed(base_url):
         mock_post.assert_called_once_with(base_url, json=payload)
 
 
+def test_deployment_finished_notification_with_no_repository_url(base_url):
+    ''' Test deployment finished notification with no repository url. '''
+    notify_params = dict(
+        branch='temp',
+        commit='tttt',
+        branch_url=None,
+        commit_url=None,
+        public_url='http://public-url',
+        host='test-notify-deploying-host',
+        repository_url=None,
+        project_name='project-name',
+        server_name='stage',
+        server_link='http://server-link',
+        user='user',
+    )
+    payload = {
+        'color': 'purple',
+        'message': 'user finished deploying project-name:temp (tttt) to <a href="http://public-url">stage</a> server.',
+        'notify': True,
+        'message_format': 'html'
+    }
+
+    with patch('requests.post') as mock_post:
+        hipchat.send(DEPLOYMENT_FINISHED, **notify_params)
+        mock_post.assert_called_once_with(base_url, json=payload)
+
+
+def test_deployment_started_notification_with_no_repository_url(base_url):
+    ''' Test deployment started notification with no repository url. '''
+    notify_params = dict(
+        branch='temp',
+        commit='tttt',
+        branch_url=None,
+        commit_url=None,
+        public_url='http://public-url',
+        host='test-notify-deploying-host',
+        repository_url=None,
+        project_name='project-name',
+        server_name='stage',
+        server_link='http://server-link',
+        user='user',
+    )
+    payload = {
+        'color': 'green',
+        'message': 'user is deploying project-name:temp (tttt) to <a href="http://public-url">stage</a> server.',
+        'notify': True,
+        'message_format': 'html'
+    }
+
+    with patch('requests.post') as mock_post:
+        hipchat.send(DEPLOYMENT_STARTED, **notify_params)
+        mock_post.assert_called_once_with(base_url, json=payload)
+
+
 def test_notity_deployment_finished_with_no_commit(base_url):
     ''' Test deployment finished notification with no commit. '''
     notify_params = dict(

--- a/tests/api/test_notif.py
+++ b/tests/api/test_notif.py
@@ -231,9 +231,11 @@ def test_notif_without_repository_url(hipchat_send_m, hipchat_is_enabled_m, gsc_
 
     assert call2[0][0] == DEPLOYMENT_STARTED
     assert call2[1]['branch'] is None
+    assert call1[1]['branch_url'] is None
+    assert call1[1]['commit_url'] is None
+    assert call2[1]['repository_url'] is None
     assert call2[1]['host'] == 'example.com'
     assert call2[1]['project_name'] == 'test-project'
     assert call2[1]['public_url'] == 'https://example.com'
-    assert call2[1]['repository_url'] == None
     assert call2[1]['server_name'] == 'test-server'
     assert call2[1]['user'] == 'ssh-user'

--- a/tests/api/test_notif.py
+++ b/tests/api/test_notif.py
@@ -130,3 +130,56 @@ def test_notif_sends_hipchat_notification(hipchat_send_m, hipchat_is_enabled_m, 
     assert call2[1]['repository_url'] == 'https://github.com/kabirbaidhya/boss'
     assert call2[1]['server_name'] == 'test-server'
     assert call2[1]['user'] == 'ssh-user'
+
+
+@patch('boss.api.notif.get_config')
+@patch('boss.api.notif.get_stage_config')
+@patch('boss.api.hipchat.is_enabled')
+@patch('boss.api.hipchat.send')
+def test_notif_without_commit(hipchat_send_m, hipchat_is_enabled_m, gsc_m, get_m):
+    ''' Test notif.send sends hipchat notification if hipchat is enabled. '''
+    get_m.return_value = {
+        'project_name': 'test-project',
+        'project_description': 'Just a test project',
+        'repository_url': 'https://github.com/kabirbaidhya/boss',
+    }
+    gsc_m.return_value = {
+        'public_url': 'https://example.com',
+        'host': 'example.com'
+    }
+    hipchat_is_enabled_m.return_value = True
+    branch_url = 'https://github.com/kabirbaidhya/boss/tree/my-branch'
+
+    # Trigger deployment finished notification
+    notif.send(DEPLOYMENT_FINISHED, {
+        'user': 'ssh-user',
+        'branch': 'my-branch',
+        'stage': 'test-server'
+    })
+
+    # Trigger Deployment Started notification with no branch
+    notif.send(DEPLOYMENT_STARTED, {
+        'user': 'ssh-user',
+        'stage': 'test-server'
+    })
+
+    (call1, call2) = hipchat_send_m.call_args_list
+
+    assert call1[0][0] == DEPLOYMENT_FINISHED
+    assert call1[1]['branch'] == 'my-branch'
+    assert call1[1]['branch_url'] == branch_url
+    assert call1[1]['host'] == 'example.com'
+    assert call1[1]['project_name'] == 'test-project'
+    assert call1[1]['public_url'] == 'https://example.com'
+    assert call1[1]['repository_url'] == 'https://github.com/kabirbaidhya/boss'
+    assert call1[1]['server_name'] == 'test-server'
+    assert call1[1]['user'] == 'ssh-user'
+
+    assert call2[0][0] == DEPLOYMENT_STARTED
+    assert call2[1]['branch'] is None
+    assert call2[1]['host'] == 'example.com'
+    assert call2[1]['project_name'] == 'test-project'
+    assert call2[1]['public_url'] == 'https://example.com'
+    assert call2[1]['repository_url'] == 'https://github.com/kabirbaidhya/boss'
+    assert call2[1]['server_name'] == 'test-server'
+    assert call2[1]['user'] == 'ssh-user'

--- a/tests/api/test_notif.py
+++ b/tests/api/test_notif.py
@@ -239,3 +239,58 @@ def test_notif_without_repository_url(hipchat_send_m, hipchat_is_enabled_m, gsc_
     assert call2[1]['public_url'] == 'https://example.com'
     assert call2[1]['server_name'] == 'test-server'
     assert call2[1]['user'] == 'ssh-user'
+
+
+@patch('boss.api.notif.get_config')
+@patch('boss.api.notif.get_stage_config')
+@patch('boss.api.hipchat.is_enabled')
+@patch('boss.api.hipchat.send')
+def test_notif_without_public_url(hipchat_send_m, hipchat_is_enabled_m, gsc_m, get_m):
+    ''' Test notif.send sends hipchat notification without public_url. '''
+    get_m.return_value = {
+        'project_name': 'test-project',
+        'project_description': 'Just a test project'
+    }
+    gsc_m.return_value = {
+        'host': '127.0.0.1'
+    }
+    hipchat_is_enabled_m.return_value = True
+
+    # Trigger deployment finished notification
+    notif.send(DEPLOYMENT_FINISHED, {
+        'user': 'ssh-user',
+        'branch': 'my-branch',
+        'commit': '1234567',
+        'stage': 'test-server'
+    })
+
+    # Trigger Deployment Started notification with no branch
+    notif.send(DEPLOYMENT_STARTED, {
+        'user': 'ssh-user',
+        'stage': 'test-server'
+    })
+
+    (call1, call2) = hipchat_send_m.call_args_list
+
+    assert call1[0][0] == DEPLOYMENT_FINISHED
+    assert call1[1]['branch'] == 'my-branch'
+    assert call1[1]['commit'] == '1234567'
+    assert call1[1]['branch_url'] == None
+    assert call1[1]['commit_url'] == None
+    assert call1[1]['host'] == '127.0.0.1'
+    assert call1[1]['project_name'] == 'test-project'
+    assert call1[1]['public_url'] == '127.0.0.1'
+    assert call1[1]['repository_url'] == None
+    assert call1[1]['server_name'] == 'test-server'
+    assert call1[1]['user'] == 'ssh-user'
+
+    assert call2[0][0] == DEPLOYMENT_STARTED
+    assert call2[1]['branch'] is None
+    assert call1[1]['branch_url'] is None
+    assert call1[1]['commit_url'] is None
+    assert call2[1]['repository_url'] is None
+    assert call2[1]['host'] == '127.0.0.1'
+    assert call2[1]['project_name'] == 'test-project'
+    assert call2[1]['public_url'] == '127.0.0.1'
+    assert call2[1]['server_name'] == 'test-server'
+    assert call2[1]['user'] == 'ssh-user'

--- a/tests/api/test_notif.py
+++ b/tests/api/test_notif.py
@@ -279,7 +279,7 @@ def test_notif_without_public_url(hipchat_send_m, hipchat_is_enabled_m, gsc_m, g
     assert call1[1]['commit_url'] == None
     assert call1[1]['host'] == '127.0.0.1'
     assert call1[1]['project_name'] == 'test-project'
-    assert call1[1]['public_url'] == '127.0.0.1'
+    assert call1[1]['public_url'] == 'http://127.0.0.1'
     assert call1[1]['repository_url'] == None
     assert call1[1]['server_name'] == 'test-server'
     assert call1[1]['user'] == 'ssh-user'
@@ -291,6 +291,6 @@ def test_notif_without_public_url(hipchat_send_m, hipchat_is_enabled_m, gsc_m, g
     assert call2[1]['repository_url'] is None
     assert call2[1]['host'] == '127.0.0.1'
     assert call2[1]['project_name'] == 'test-project'
-    assert call2[1]['public_url'] == '127.0.0.1'
+    assert call2[1]['public_url'] == 'http://127.0.0.1'
     assert call2[1]['server_name'] == 'test-server'
     assert call2[1]['user'] == 'ssh-user'

--- a/tests/api/test_slack.py
+++ b/tests/api/test_slack.py
@@ -60,6 +60,68 @@ def test_send(base_url):
         mock_post.assert_called_once_with(base_url, json=payload)
 
 
+def test_send_deployment_started_with_no_repository_url(base_url):
+    ''' Test deployment started notification with no repository url. '''
+    notify_params = dict(
+        branch='temp',
+        commit='tttt',
+        commit_url=None,
+        branch_url=None,
+        repository_url=None,
+        public_url='http://public-url',
+        host='test-notify-deploying-host',
+        project_name='project-name',
+        server_name='server-name',
+        server_link='http://server-link',
+        user='user',
+    )
+
+    payload = {
+        'attachments': [
+            {
+                'color': 'good',
+                'text': 'user is deploying project-name:temp (tttt) to <http://public-url|server-name> server.',
+                'mrkdwn_in': ['text']
+            }
+        ]
+    }
+
+    with patch('requests.post') as mock_post:
+        slack.send(DEPLOYMENT_STARTED, **notify_params)
+        mock_post.assert_called_once_with(base_url, json=payload)
+
+
+def test_send_deployment_finished_with_no_repository_url(base_url):
+    ''' Test deployment finished notification with no repository url. '''
+    notify_params = dict(
+        branch='temp',
+        commit='tttt',
+        commit_url=None,
+        branch_url=None,
+        repository_url=None,
+        public_url='http://public-url',
+        host='test-notify-deploying-host',
+        project_name='project-name',
+        server_name='server-name',
+        server_link='http://server-link',
+        user='user',
+    )
+
+    payload = {
+        'attachments': [
+            {
+                'color': '#764FA5',
+                'text': 'user finished deploying project-name:temp (tttt) to <http://public-url|server-name> server.',
+                'mrkdwn_in': ['text']
+            }
+        ]
+    }
+
+    with patch('requests.post') as mock_post:
+        slack.send(DEPLOYMENT_FINISHED, **notify_params)
+        mock_post.assert_called_once_with(base_url, json=payload)
+
+
 def test_send_with_no_branch_name(base_url):
     '''
     Test slack.send() doesn't show the branch link,

--- a/tests/api/test_slack.py
+++ b/tests/api/test_slack.py
@@ -24,6 +24,11 @@ def test_create_link():
     assert slack.create_link(url, title) == expected_link
 
 
+def test_create_link_supports_empty_url():
+    ''' Test slack.create_link() supports empty url. '''
+    assert slack.create_link(None, 'Test') == 'Test'
+
+
 def test_send(base_url):
     ''' Test slack.send(). '''
     notify_params = dict(

--- a/tests/api/test_slack.py
+++ b/tests/api/test_slack.py
@@ -205,6 +205,58 @@ def test_notity_deployed_with_no_branch_name(base_url):
         mock_post.assert_called_once_with(base_url, json=payload)
 
 
+def test_notity_deployment_finished_with_no_commit_no_branch(base_url):
+    ''' Test sending deployment finished notification with no commit and no branch. '''
+    notify_params = dict(
+        public_url='http://public-url',
+        host='test-notify-deployed-host',
+        repository_url='http://repository-url',
+        project_name='project-name',
+        server_name='server-name',
+        server_link='http://server-link',
+        user='user'
+    )
+    payload = {
+        'attachments': [
+            {
+                'color': '#764FA5',
+                'text': 'user finished deploying <http://repository-url|project-name> to <http://public-url|server-name> server.',
+                'mrkdwn_in': ['text']
+            }
+        ]
+    }
+
+    with patch('requests.post') as mock_post:
+        slack.send(DEPLOYMENT_FINISHED, **notify_params)
+        mock_post.assert_called_once_with(base_url, json=payload)
+
+
+def test_notity_deployment_started_with_no_commit_no_branch(base_url):
+    ''' Test sending deployment started notification with no commit and no branch. '''
+    notify_params = dict(
+        public_url='http://public-url',
+        host='test-notify-deployed-host',
+        repository_url='http://repository-url',
+        project_name='project-name',
+        server_name='server-name',
+        server_link='http://server-link',
+        user='user'
+    )
+    payload = {
+        'attachments': [
+            {
+                'color': 'good',
+                'text': 'user is deploying <http://repository-url|project-name> to <http://public-url|server-name> server.',
+                'mrkdwn_in': ['text']
+            }
+        ]
+    }
+
+    with patch('requests.post') as mock_post:
+        slack.send(DEPLOYMENT_STARTED, **notify_params)
+        mock_post.assert_called_once_with(base_url, json=payload)
+
+
 def test_send_running_script_started_notification(base_url):
     ''' Test send() sends RUNNING_SCRIPT_STARTED notfication. '''
     notify_params = dict(

--- a/tests/api/test_slack.py
+++ b/tests/api/test_slack.py
@@ -324,6 +324,29 @@ def test_notity_deployment_started_with_no_commit_no_branch(base_url):
         mock_post.assert_called_once_with(base_url, json=payload)
 
 
+def test_notity_deployment_started_no_links_at_all(base_url):
+    ''' Test deployment started notification with no links or urls at all. '''
+    notify_params = dict(
+        project_name='project-name',
+        server_name='staging',
+        user='user',
+    )
+
+    payload = {
+        'attachments': [
+            {
+                'color': 'good',
+                'text': 'user is deploying project-name to staging server.',
+                'mrkdwn_in': ['text']
+            }
+        ]
+    }
+
+    with patch('requests.post') as mock_post:
+        slack.send(DEPLOYMENT_STARTED, **notify_params)
+        mock_post.assert_called_once_with(base_url, json=payload)
+
+
 def test_send_running_script_started_notification(base_url):
     ''' Test send() sends RUNNING_SCRIPT_STARTED notfication. '''
     notify_params = dict(

--- a/tests/api/test_slack.py
+++ b/tests/api/test_slack.py
@@ -117,6 +117,62 @@ def test_notity_deployed(base_url):
         mock_post.assert_called_once_with(base_url, json=payload)
 
 
+def test_notity_deployed_with_no_commit(base_url):
+    ''' Test sending deployment finished notification with no commit. '''
+    notify_params = dict(
+        branch_url='http://branch-url',
+        branch='temp',
+        public_url='http://public-url',
+        host='test-notify-deployed-host',
+        repository_url='http://repository-url',
+        project_name='project-name',
+        server_name='server-name',
+        server_link='http://server-link',
+        user='user'
+    )
+    payload = {
+        'attachments': [
+            {
+                'color': '#764FA5',
+                'text': 'user finished deploying <http://repository-url|project-name>:<http://branch-url|temp> to <http://public-url|server-name> server.',
+                'mrkdwn_in': ['text']
+            }
+        ]
+    }
+
+    with patch('requests.post') as mock_post:
+        slack.send(DEPLOYMENT_FINISHED, **notify_params)
+        mock_post.assert_called_once_with(base_url, json=payload)
+
+
+def test_notity_deploying_with_no_commit(base_url):
+    ''' Test sending deployment started notification with no commit. '''
+    notify_params = dict(
+        branch_url='http://branch-url',
+        branch='temp',
+        public_url='http://public-url',
+        host='test-notify-deployed-host',
+        repository_url='http://repository-url',
+        project_name='project-name',
+        server_name='server-name',
+        server_link='http://server-link',
+        user='user'
+    )
+    payload = {
+        'attachments': [
+            {
+                'color': 'good',
+                'text': 'user is deploying <http://repository-url|project-name>:<http://branch-url|temp> to <http://public-url|server-name> server.',
+                'mrkdwn_in': ['text']
+            }
+        ]
+    }
+
+    with patch('requests.post') as mock_post:
+        slack.send(DEPLOYMENT_STARTED, **notify_params)
+        mock_post.assert_called_once_with(base_url, json=payload)
+
+
 def test_notity_deployed_with_no_branch_name(base_url):
     '''
     Test slack.notify_deployed() doesn't show the branch link,


### PR DESCRIPTION
* Make config options like `public_url`, `repository_url` optional.
  - If `public_url` is not provided, the `host` option is taken as a fallback value.
  - If `repository_url` is not provided the notification message would use plain text (instead of links) for project url, branch url and commit url.
* Notification messages with or without branch, branch link, commit, commit link and repository urls are supported now. Including bare minimal messages without any links at all.
* Add tests for git util functions `get_tree_url` and `get_commit_url`
* Add more tests related to notification to ensure all of these cases are handled.
* 100 tests passed on master :100: 