### PR TITLE
Improvements on Remote source deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,10 +82,10 @@ project_description: 'My App'
 repository_url: 'https://github.com/username/repository'
 branch_url: '{repository_url}/tree/{branch}'
 user: deploy_user
-app_dir: /source/my-app
 
 deployment:
   preset: remote-source
+  base_dir: /source/my-app
 
 stages:
   prod:

--- a/boss.yml.example
+++ b/boss.yml.example
@@ -1,4 +1,4 @@
-app_dir: /path/to/remote/app/directory
+cwd: /path/to/remote/app/directory
 project_name: 'projectname'
 project_description: 'Project Description'
 repository_url: YOUR_GIT_REPOSITORY_URL

--- a/boss/api/deployment/preset/remote_source.py
+++ b/boss/api/deployment/preset/remote_source.py
@@ -61,6 +61,7 @@ def run_deploy_script(stage, branch):
     env_vars = dict(
         STAGE=stage,
         BRANCH=branch,
+        BASE_DIR=get_deploy_dir(),
         REPOSITORY_PATH=repo_path,
         REPOSITORY_URL=get_config()['repository_url'],
         SCRIPT_BUILD=runner.get_script_cmd(known_scripts.BUILD),

--- a/boss/api/deployment/preset/remote_source.py
+++ b/boss/api/deployment/preset/remote_source.py
@@ -50,9 +50,10 @@ def deploy(branch=None):
         REPOSITORY_URL=get_config()['repository_url']
     )
 
-    with shell_env(**env_vars):
-        # Run the sync script on the remote
-        runner.run('sh ' + script_path)
+    with hide('running'):
+        with shell_env(**env_vars):
+            # Run the sync script on the remote
+            runner.run('sh ' + script_path)
 
     with cd(repo_path):
         install_dependencies()

--- a/boss/api/deployment/preset/remote_source.py
+++ b/boss/api/deployment/preset/remote_source.py
@@ -73,11 +73,6 @@ def sync(branch=None):
         runner.run('mkdir -p ' + repo_path)
         fs.upload(BASE_PATH + '/misc/scripts/sync.sh', script_path)
 
-    # Check if the script exists (with version) on the remote.
-    if not fs.exists(script_path):
-        runner.run('mkdir -p ' + repo_path)
-        fs.upload(BASE_PATH + '/misc/scripts/sync.sh', script_path)
-
     env_vars = dict(
         STAGE=stage,
         BRANCH=branch,

--- a/boss/api/deployment/preset/remote_source.py
+++ b/boss/api/deployment/preset/remote_source.py
@@ -19,6 +19,7 @@ from boss.core.util.colors import cyan
 from boss.core.constants import known_scripts, notification_types
 from boss.api.deployment.buildman import get_deploy_dir
 
+REMOTE_INIT_SCRIPT = '/init-{}.sh'.format(__version__)
 REMOTE_SCRIPT = '/deploy-{}.sh'.format(__version__)
 REPOSITORY_PATH = '/repo'
 
@@ -47,12 +48,17 @@ def get_repo_path():
 def run_deploy_script(stage, branch):
     ''' Run the deployment script on the remote host. '''
     script_path = get_deploy_dir() + REMOTE_SCRIPT
+    init_script_path = get_deploy_dir() + REMOTE_INIT_SCRIPT
     repo_path = get_repo_path()
 
     # Check if the script exists (with version) on the remote.
     if not fs.exists(script_path):
-        with hide('running'):
+        with hide('everything'):
             runner.run('mkdir -p ' + repo_path)
+            fs.upload(
+                BASE_PATH + '/misc/scripts/init.sh',
+                init_script_path
+            )
             fs.upload(
                 BASE_PATH + '/misc/scripts/remote-source-deploy.sh',
                 script_path
@@ -62,6 +68,7 @@ def run_deploy_script(stage, branch):
         STAGE=stage,
         BRANCH=branch,
         BASE_DIR=get_deploy_dir(),
+        INIT_SCRIPT_PATH=init_script_path,
         REPOSITORY_PATH=repo_path,
         REPOSITORY_URL=get_config()['repository_url'],
         SCRIPT_BUILD=runner.get_script_cmd(known_scripts.BUILD),

--- a/boss/api/deployment/preset/remote_source.py
+++ b/boss/api/deployment/preset/remote_source.py
@@ -22,15 +22,15 @@ from boss.core.constants import known_scripts, notification_types
 def deploy(branch=None):
     ''' Deploy to remote source. '''
     stage = shell.get_stage()
-    deployer_user = shell.get_user()
     branch = branch or get_stage_config(stage)['branch']
-    commit = git.last_commit(short=True)
-    notif.send(notification_types.DEPLOYMENT_STARTED, {
-        'user': deployer_user,
-        'branch': branch,
-        'commit': commit,
-        'stage': stage
-    })
+    params = dict(
+        commit=git.last_commit(short=True),
+        user=shell.get_user(),
+        stage=stage,
+        branch=branch
+    )
+
+    notif.send(notification_types.DEPLOYMENT_STARTED, params)
 
     # Get the latest code from the repository
     sync(branch)
@@ -40,13 +40,7 @@ def deploy(branch=None):
     build(stage)
     reload_service()
 
-    notif.send(notification_types.DEPLOYMENT_FINISHED, {
-        'user': deployer_user,
-        'branch': branch,
-        'commit': commit,
-        'stage': stage
-    })
-
+    notif.send(notification_types.DEPLOYMENT_FINISHED, params)
     remote_info('Deployment Completed')
 
 

--- a/boss/api/runner.py
+++ b/boss/api/runner.py
@@ -26,6 +26,13 @@ def is_script_defined(script):
     return custom_scripts.has_key(script)
 
 
+def get_script_cmd(script):
+    ''' Return a script command if it does exist. '''
+    scripts = _get_config()['scripts']
+
+    return scripts.get(script)
+
+
 def run_script_safely(script, remote=True):
     '''
     Run a script only if it is defined in the config.

--- a/boss/config.py
+++ b/boss/config.py
@@ -115,7 +115,7 @@ def get_base_config(resolved_config=None):
         'user': config.get('user'),
         'port': config.get('port'),
         'branch': config.get('branch'),
-        'app_dir': config.get('app_dir'),
+        'cwd': config.get('cwd'),
         'deployment': config.get('deployment'),
         'repository_url': config.get('repository_url'),
         'remote_env_path': config.get('remote_env_path')

--- a/boss/core/constants/config.py
+++ b/boss/core/constants/config.py
@@ -11,10 +11,10 @@ from .known_scripts import (
 DEFAULT_CONFIG = {
     'user': 'app',
     'port': 22,
+    'cwd': '/home/app',
     'key_filename': '~/.ssh/id_rsa',
     'ssh_forward_agent': False,
     'verbose_logging': False,
-    'app_dir': '~/',
     'branch': 'master',
     'repository_url': '',
     'project_name': 'untitled',

--- a/boss/init.py
+++ b/boss/init.py
@@ -57,7 +57,7 @@ def configure_env():
     stage_config = get_stage_config(stage)
     env.user = stage_config.get('user') or config['user']
     env.port = stage_config.get('port') or config['port']
-    env.cwd = stage_config.get('app_dir') or config['app_dir']
+    env.cwd = stage_config.get('cwd') or config['cwd']
     env.key_filename = stage_config.get(
         'key_filename') or config['key_filename']
     env.hosts = [stage_config['host']]

--- a/boss/misc/scripts/init.sh
+++ b/boss/misc/scripts/init.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+# Boss Utilities
+COLOR_GREEN='\033[0;32m'
+COLOR_RED='\033[0;31m'
+COLOR_CYAN='\033[0;36m'
+COLOR_OFF='\033[0m'
+
+echo_info() {
+  printf "${COLOR_GREEN}${1}${COLOR_OFF}\n"
+}
+
+echo_fade() {
+  printf "${COLOR_CYAN}${1}${COLOR_OFF}\n"
+}
+
+echo_error() {
+  printf "${COLOR_RED}${1}${COLOR_OFF}\n"
+}

--- a/boss/misc/scripts/remote-source-deploy.sh
+++ b/boss/misc/scripts/remote-source-deploy.sh
@@ -1,37 +1,50 @@
 #!/bin/sh
 
+# Initialize the deployment script
+. "$INIT_SCRIPT_PATH"
+
 mkdir -p $REPOSITORY_PATH
 cd $REPOSITORY_PATH
 
 if [ -d ".git" ]; then
-  printf "\nFetching the latest changes."
+  echo_info "Fetching the latest changes."
   git fetch --prune
 
-  printf "\nChecking out to branch ${BRANCH}."
+  echo_info "Checking out to branch ${BRANCH}."
   git checkout -f $BRANCH
+  echo;
+
+  echo_info "Synchronizing with the latest changes on branch ${BRANCH}."
+  git reset --hard origin/$BRANCH
 else
   git clone -b $BRANCH  $REPOSITORY_URL $REPOSITORY_PATH
 fi
-
-printf "\nSynchronizing with the latest changes on branch ${BRANCH}.\n"
-git reset --hard origin/$BRANCH
+echo;
 
 if [ ! -z "$SCRIPT_INSTALL" ]; then
-  printf "\n> $SCRIPT_INSTALL\n";
+  echo_info "Running install"
+  echo_fade "> $SCRIPT_INSTALL";
   $SCRIPT_INSTALL;
+  echo;
 fi
 
 if [ ! -z "$SCRIPT_BUILD" ]; then
-  printf "\n> $SCRIPT_BUILD\n";
+  echo_info "Running build"
+  echo_fade "> $SCRIPT_BUILD";
   $SCRIPT_BUILD;
+  echo;
 fi
 
 if [ ! -z "$SCRIPT_RELOAD" ]; then
-  printf "\n> $SCRIPT_RELOAD\n";
+  echo_info "Running reload"
+  echo_fade "> $SCRIPT_RELOAD";
   $SCRIPT_RELOAD;
+  echo;
 fi
 
 if [ ! -z "$SCRIPT_STATUS_CHECK\n" ]; then
-  printf "\n> $SCRIPT_STATUS_CHECK";
+  echo_info "Running status_check"
+  echo_fade "> $SCRIPT_STATUS_CHECK";
   $SCRIPT_STATUS_CHECK;
+  echo;
 fi

--- a/boss/misc/scripts/remote-source-deploy.sh
+++ b/boss/misc/scripts/remote-source-deploy.sh
@@ -11,7 +11,27 @@ if [ -d ".git" ]; then
   git checkout -f $BRANCH
 else
   git clone -b $BRANCH  $REPOSITORY_URL $REPOSITORY_PATH
-fi;
+fi
 
 printf "\nSynchronizing with the latest changes on branch ${BRANCH}.\n"
 git reset --hard origin/$BRANCH
+
+if [ ! -z "$SCRIPT_INSTALL" ]; then
+  printf "\n> $SCRIPT_INSTALL\n";
+  $SCRIPT_INSTALL;
+fi
+
+if [ ! -z "$SCRIPT_BUILD" ]; then
+  printf "\n> $SCRIPT_BUILD\n";
+  $SCRIPT_BUILD;
+fi
+
+if [ ! -z "$SCRIPT_RELOAD" ]; then
+  printf "\n> $SCRIPT_RELOAD\n";
+  $SCRIPT_RELOAD;
+fi
+
+if [ ! -z "$SCRIPT_STATUS_CHECK\n" ]; then
+  printf "\n> $SCRIPT_STATUS_CHECK";
+  $SCRIPT_STATUS_CHECK;
+fi

--- a/boss/misc/scripts/sync.sh
+++ b/boss/misc/scripts/sync.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+mkdir -p $REPOSITORY_PATH
+cd $REPOSITORY_PATH
+
+if [ -d ".git" ]; then
+  echo "Fetching the latest changes."
+  git fetch --prune
+
+  echo "Checking out to branch ${BRANCH}."
+  git checkout -f $BRANCH
+else
+  git clone -b $BRANCH  $REPOSITORY_URL $REPOSITORY_PATH
+fi;
+
+echo "Synchronizing with the latest changes."
+git reset --hard origin/$BRANCH

--- a/boss/misc/scripts/sync.sh
+++ b/boss/misc/scripts/sync.sh
@@ -4,14 +4,14 @@ mkdir -p $REPOSITORY_PATH
 cd $REPOSITORY_PATH
 
 if [ -d ".git" ]; then
-  echo "Fetching the latest changes."
+  printf "\nFetching the latest changes."
   git fetch --prune
 
-  echo "Checking out to branch ${BRANCH}."
+  printf "\nChecking out to branch ${BRANCH}."
   git checkout -f $BRANCH
 else
   git clone -b $BRANCH  $REPOSITORY_URL $REPOSITORY_PATH
 fi;
 
-echo "Synchronizing with the latest changes."
+printf "\nSynchronizing with the latest changes on branch ${BRANCH}.\n"
 git reset --hard origin/$BRANCH

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -121,14 +121,14 @@ The public url to access this website.
 public_url: http://dev.your-app.com
 ```
 
-##### `app_dir`
+##### `cwd`
 
 `string`
 
-The absolute path of the project root directory in the server.
+The absolute path of the current working directory on the remote host.
 
 ```yml
-app_dir: /path/to/your/app
+cwd: /path/to/your/app
 ```
 
 ##### `logging`
@@ -310,7 +310,7 @@ stages:
   dev:
     host: dev.your-app.com
     public_url: http://dev.your-app.com
-    app_dir: /path/to/your/app
+    cwd: /path/to/your/app
     logging:
       files:
         - /path/to/error/log/file
@@ -318,7 +318,7 @@ stages:
   uat:
     host: uat.your-app.com
     public_url: http://uat.your-app.com
-    app_dir: /path/to/your/app
+    cwd: /path/to/your/app
     logging:
       files:
         - /path/to/error/log/file
@@ -328,7 +328,7 @@ stages:
     port: ${PRODUCTION_SERVER_SSH_PORT}
     username: ${PRODUCTION_SERVER_USERNAME}
     public_url: http://your-app.com
-    app_dir: /path/to/your/app
+    cwd: /path/to/your/app
     logging:
       files:
         - /path/to/error/log/file


### PR DESCRIPTION
## Changes
* The git repository is cloned on the remote if it doesn't already exists. If it exists then it's synchronized to the remote origin branch.
* Use sh script to lessen the overhead of back and forth remote execution over ssh.
* Refactor remote source deployment logic using a shell script to do the remote execution on the remote end.

## Breaking Changes
* Remote source deployment relies on `base_dir` instead of `app_dir`.
* Remote source deployment puts the git repository on a directory `repo` inside the provided `base_dir`.
* The `app_dir` config option is renamed to `cwd` and  could now be only used to set the remote working directory for the execution.

