### PR TITLE
Create project directory under the configured base_dir for each deployment

### DIFF
--- a/boss/api/deployment/buildman.py
+++ b/boss/api/deployment/buildman.py
@@ -40,7 +40,12 @@ def get_deploy_dir():
     ''' Get the deployment base directory path. '''
     config = get_stage_config(shell.get_stage())
 
-    return config['deployment']['base_dir'].rstrip('/')
+    deploy_dir = '{}/{}'.format(
+        config['deployment']['base_dir'].rstrip('/'),
+        get_config()['project_name']
+    )
+
+    return deploy_dir
 
 
 def resolve_local_build_dir():

--- a/boss/config.py
+++ b/boss/config.py
@@ -98,6 +98,8 @@ def load(filename=DEFAULT_CONFIG_FILE, stage=None):
 
         _config.update(merged_config)
 
+        validate(_config)
+
         return get()
 
     except KeyError:
@@ -130,3 +132,11 @@ def get_stage_config(stage):
         halt('Unknown stage %s. Stage should be any one of %s' % (
             stage, _config['stages'].keys()
         ))
+
+
+def validate(config):
+    ''' Validate loaded configuration. '''
+
+    # TODO: Instead of failing, ask the params and update boss.yml instead.
+    if not config.get('project_name'):
+        halt('`project_name` is not set.')

--- a/boss/core/constants/config.py
+++ b/boss/core/constants/config.py
@@ -17,7 +17,7 @@ DEFAULT_CONFIG = {
     'verbose_logging': False,
     'branch': 'master',
     'repository_url': '',
-    'project_name': 'untitled',
+    'project_name': None,
     'project_description': '',
     'branch_url': '{repository_url}/branch/{branch}',
     'remote_env_injection': False,


### PR DESCRIPTION
* Create project directory under the configured base_dir for each deployment
* Config option `project_name` is required and the cli throws error if it's not provided.
