### PR TITLE
Use && to run multiple commands instead of ;

### DIFF
--- a/boss/api/ssh.py
+++ b/boss/api/ssh.py
@@ -20,7 +20,7 @@ def run(command, **params):
     # If command is a list of commands,
     # concat the commands and run them all.
     if not is_string(command) and is_iterable(command):
-        command = '; '.join(command)
+        command = '&& '.join(command)
 
     # Execute the command and get the IO streams.
     (stdin, stdout, stderr) = remote.run(resolve_client(), command, **params)


### PR DESCRIPTION
* Use `&&` to run multiple commands instead of `;` for `ssh.run`
* This seems to result unexpected behavior.
* More on this could be found here https://stackoverflow.com/questions/6152659/bash-sh-difference-between-and.