### PR TITLE
Add install hook scripts pre_install and post_install

### DIFF
--- a/boss/api/deployment/buildman.py
+++ b/boss/api/deployment/buildman.py
@@ -407,6 +407,6 @@ def build(stage, config):
     env_vars = get_build_env_vars(stage, config)
 
     with shell_env(**env_vars):
-        runner.run_script(known_scripts.PRE_BUILD, remote=False)
+        runner.run_script_safely(known_scripts.PRE_BUILD, remote=False)
         runner.run_script(known_scripts.BUILD, remote=False)
-        runner.run_script(known_scripts.POST_BUILD, remote=False)
+        runner.run_script_safely(known_scripts.POST_BUILD, remote=False)

--- a/boss/api/deployment/buildman.py
+++ b/boss/api/deployment/buildman.py
@@ -400,7 +400,9 @@ def build(stage, config):
     info('Getting the build ready for deployment')
 
     # Trigger the install script
+    runner.run_script_safely(known_scripts.PRE_INSTALL, remote=False)
     runner.run_script(known_scripts.INSTALL, remote=False)
+    runner.run_script_safely(known_scripts.POST_INSTALL, remote=False)
 
     env_vars = get_build_env_vars(stage, config)
 

--- a/boss/api/deployment/preset/node.py
+++ b/boss/api/deployment/preset/node.py
@@ -157,10 +157,16 @@ def deploy():
 def install_remote_dependencies():
     ''' Install dependencies on the remote host. '''
     remote_info('Installing dependencies on the remote')
+    runner.run_script_safely(known_scripts.PRE_INSTALL)
+
     if runner.is_script_defined(known_scripts.INSTALL_REMOTE):
+        runner.run_script_safely(known_scripts.PRE_INSTALL_REMOTE)
         runner.run_script(known_scripts.INSTALL_REMOTE)
+        runner.run_script_safely(known_scripts.POST_INSTALL_REMOTE)
     else:
-        runner.run_script(known_scripts.INSTALL)
+        runner.run_script_safely(known_scripts.INSTALL)
+
+    runner.run_script_safely(known_scripts.POST_INSTALL)
 
 
 def start_or_reload_service(has_started=False):

--- a/boss/api/deployment/preset/remote_source.py
+++ b/boss/api/deployment/preset/remote_source.py
@@ -58,7 +58,9 @@ def reload_service():
 
 def install_dependencies():
     ''' Install dependencies. '''
+    runner.run_script_safely(known_scripts.PRE_INSTALL)
     runner.run_script_safely(known_scripts.INSTALL)
+    runner.run_script_safely(known_scripts.POST_INSTALL)
 
 
 @task

--- a/boss/core/constants/known_scripts.py
+++ b/boss/core/constants/known_scripts.py
@@ -16,3 +16,7 @@ START_OR_RELOAD = 'start_or_reload'
 # Hook Scripts
 PRE_BUILD = 'pre_build'
 POST_BUILD = 'post_build'
+PRE_INSTALL = 'pre_install'
+POST_INSTALL = 'post_install'
+PRE_INSTALL_REMOTE = 'pre_install_remote'
+POST_INSTALL_REMOTE = 'post_install_remote'


### PR DESCRIPTION
- Add install hook scripts `pre_install` and `post_install` that run before and after the `install` step.
- Add additional hook scripts `pre_install_remote` and `post_install_remote` that run before and after the `install_remote` step.
- Fix an issue with pre/post build hooks