### PR TITLE
Add deployment hook scripts pre_deploy and post_deploy 

### DIFF
--- a/boss/api/deployment/preset/node.py
+++ b/boss/api/deployment/preset/node.py
@@ -84,6 +84,7 @@ def deploy():
         'branch': branch,
         'stage': stage
     })
+    runner.run_script_safely(known_scripts.PRE_DEPLOY)
 
     (release_dir, current_path) = buildman.setup_remote()
 
@@ -142,6 +143,8 @@ def deploy():
         'createdBy': deployer_user,
         'timestamp': timestamp.strftime(buildman.TS_FORMAT)
     })
+
+    runner.run_script_safely(known_scripts.POST_DEPLOY)
 
     # Send deployment finished notification.
     notif.send(notification_types.DEPLOYMENT_FINISHED, {

--- a/boss/api/deployment/preset/remote_source.py
+++ b/boss/api/deployment/preset/remote_source.py
@@ -31,6 +31,7 @@ def deploy(branch=None):
         'commit': commit,
         'stage': stage
     })
+    runner.run_script_safely(known_scripts.PRE_DEPLOY)
 
     # Get the latest code from the repository
     sync(branch)
@@ -39,6 +40,7 @@ def deploy(branch=None):
     # Building the app
     build(stage)
     reload_service()
+    runner.run_script_safely(known_scripts.POST_DEPLOY)
 
     notif.send(notification_types.DEPLOYMENT_FINISHED, {
         'user': deployer_user,

--- a/boss/api/deployment/preset/web.py
+++ b/boss/api/deployment/preset/web.py
@@ -12,10 +12,10 @@ from datetime import datetime
 from fabric.api import task, cd
 
 from boss.util import remote_info
-from boss.api import shell, notif, fs, git
+from boss.api import shell, notif, fs, git, runner
 from boss.config import get_stage_config, get as get_config
 from boss.core.output import info
-from boss.core.constants import notification_types
+from boss.core.constants import notification_types, known_scripts
 from .. import buildman
 
 
@@ -74,6 +74,8 @@ def deploy():
         'stage': stage
     })
 
+    runner.run_script_safely(known_scripts.PRE_DEPLOY)
+
     (release_dir, current_path) = buildman.setup_remote()
 
     timestamp = datetime.utcnow()
@@ -124,6 +126,8 @@ def deploy():
         'createdBy': deployer_user,
         'timestamp': timestamp.strftime(buildman.TS_FORMAT)
     })
+
+    runner.run_script_safely(known_scripts.POST_DEPLOY)
 
     # Send deployment finished notification.
     notif.send(notification_types.DEPLOYMENT_FINISHED, {

--- a/boss/core/constants/known_scripts.py
+++ b/boss/core/constants/known_scripts.py
@@ -16,6 +16,8 @@ START_OR_RELOAD = 'start_or_reload'
 # Hook Scripts
 PRE_BUILD = 'pre_build'
 POST_BUILD = 'post_build'
+PRE_DEPLOY = 'pre_deploy'
+POST_DEPLOY = 'post_deploy'
 PRE_INSTALL = 'pre_install'
 POST_INSTALL = 'post_install'
 PRE_INSTALL_REMOTE = 'pre_install_remote'


### PR DESCRIPTION
Add deployment hook scripts `pre_deploy` and `post_deploy` that run before and after the deployment process 