### PR TITLE
Make install script optional for node and web deployments

### DIFF
--- a/boss/api/deployment/buildman.py
+++ b/boss/api/deployment/buildman.py
@@ -401,7 +401,7 @@ def build(stage, config):
 
     # Trigger the install script
     runner.run_script_safely(known_scripts.PRE_INSTALL, remote=False)
-    runner.run_script(known_scripts.INSTALL, remote=False)
+    runner.run_script_safely(known_scripts.INSTALL, remote=False)
     runner.run_script_safely(known_scripts.POST_INSTALL, remote=False)
 
     env_vars = get_build_env_vars(stage, config)


### PR DESCRIPTION
Make `install` script optional for `node` and `web` deployments. Right now deployment fails if `install` script is not provided or default could not be resolved.