### PR TITLE
Fix CVE-2018-18074 vulnerablility due to requests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ setup(
         'fabric==1.14.0',
         'paramiko==2.4.2',
         'pyyaml==3.12',
-        'requests==2.17.3',
+        'requests==2.20.0',
         'inquirer==2.2.0',
         'python-dotenv==0.6.5',
         'terminaltables==3.1.0',


### PR DESCRIPTION
Fix CVE-2018-18074 vulnerablility due to requests. Use requests==2.20.0.