### PR TITLE
Make build script optional supporting node projects w/o build script

### DIFF
--- a/boss/api/deployment/buildman.py
+++ b/boss/api/deployment/buildman.py
@@ -408,5 +408,5 @@ def build(stage, config):
 
     with shell_env(**env_vars):
         runner.run_script_safely(known_scripts.PRE_BUILD, remote=False)
-        runner.run_script(known_scripts.BUILD, remote=False)
+        runner.run_script_safely(known_scripts.BUILD, remote=False)
         runner.run_script_safely(known_scripts.POST_BUILD, remote=False)

--- a/boss/core/constants/config.py
+++ b/boss/core/constants/config.py
@@ -1,11 +1,7 @@
 ''' Configuration Constants. '''
 
 from . import ci, presets
-from .known_scripts import (
-    INSTALL,
-    INSTALL_REMOTE,
-    BUILD
-)
+from .known_scripts import (INSTALL, INSTALL_REMOTE)
 
 
 DEFAULT_CONFIG = {
@@ -79,7 +75,6 @@ PSD[presets.NODE] = {
     },
     'scripts': {
         INSTALL: 'npm install',
-        INSTALL_REMOTE: 'npm install',
-        BUILD: 'npm run build'
+        INSTALL_REMOTE: 'npm install'
     }
 }


### PR DESCRIPTION
Make build script optional supporting node projects w/o build script