### PR TITLE
Support complete endpoint for Stripe notification

### DIFF
--- a/boss/api/slack.py
+++ b/boss/api/slack.py
@@ -10,7 +10,7 @@ from boss.core.util.func import as_is
 
 def send(notif_type, **params):
     ''' Send slack notifications. '''
-    url = config()['base_url'] + config()['endpoint']
+    url = slack_url(config()['base_url'] + config()['endpoint'])
 
     (text, color) = notification.get(
         notif_type,
@@ -54,6 +54,9 @@ def create_link(url, title):
         title=title
     )
 
+def slack_url(base_url, endpoint):
+    ''' Return slack endpoint by concatinating the base_url if required '''
+    return endpoint if base_url in endpoint else (base_url + endpoint)
 
 def pre_format(text):
     ''' Return pre-formatted text for slack. '''

--- a/boss/api/slack.py
+++ b/boss/api/slack.py
@@ -10,7 +10,7 @@ from boss.core.util.func import as_is
 
 def send(notif_type, **params):
     ''' Send slack notifications. '''
-    url = slack_url(config()['base_url'] + config()['endpoint'])
+    url = slack_url(config()['base_url'], config()['endpoint'])
 
     (text, color) = notification.get(
         notif_type,


### PR DESCRIPTION
The current implementation does not handle the case of a complete stripe endpoint (as provided by Stripe) in its configuration. I could not find anything in the documentation of how the original endpoint needs to be split for the config to work. Also, it stands to reason that a user would assume that the URL provided by Stripe (they even copy it to clipboard!) would work as-is.

The implementation is such that partial endpoints will continue to work.