### PR TITLE
Improvements and tests on the slack url config

### DIFF
--- a/boss/api/slack.py
+++ b/boss/api/slack.py
@@ -54,9 +54,17 @@ def create_link(url, title):
         title=title
     )
 
+
 def slack_url(base_url, endpoint):
     ''' Return slack endpoint by concatinating the base_url if required '''
-    return endpoint if base_url in endpoint else (base_url + endpoint)
+    base_url = base_url.strip('/')
+    endpoint = endpoint.strip('/')
+
+    if base_url in endpoint:
+        return endpoint
+
+    return base_url + '/' + endpoint
+
 
 def pre_format(text):
     ''' Return pre-formatted text for slack. '''

--- a/tests/api/test_slack.py
+++ b/tests/api/test_slack.py
@@ -24,6 +24,25 @@ def test_create_link():
     assert slack.create_link(url, title) == expected_link
 
 
+def test_slack_url():
+    ''' Test slack_url() works. '''
+    assert slack.slack_url('', '') == ''
+    assert slack.slack_url(
+        'https://hooks.slack.com/services',
+        '/foo/bar'
+    ) == 'https://hooks.slack.com/services/foo/bar'
+
+    assert slack.slack_url(
+        'https://hooks.slack.com/services',
+        'https://hooks.slack.com/services/foo/bar'
+    ) == 'https://hooks.slack.com/services/foo/bar'
+
+    assert slack.slack_url(
+        '',
+        'https://hooks.slack.com/services/foo/bar'
+    ) == 'https://hooks.slack.com/services/foo/bar'
+
+
 def test_create_link_supports_empty_url():
     ''' Test slack.create_link() supports empty url. '''
     assert slack.create_link(None, 'Test') == 'Test'


### PR DESCRIPTION
- Ensure slack `base_url` and `endpoint` works with or without trailing / leading slashes
- Tests to ensure `slack_url` function works as expected.
