### PR TITLE
Use deployment.base_dir instead of app_dir for remote-source deployment to make config consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,10 +83,10 @@ project_description: 'My App'
 repository_url: 'https://github.com/username/repository'
 branch_url: '{repository_url}/tree/{branch}'
 user: deploy_user
-app_dir: /source/my-app
 
 deployment:
   preset: remote-source
+  base_dir: /source/my-app
 
 stages:
   prod:

--- a/boss.yml.example
+++ b/boss.yml.example
@@ -1,4 +1,3 @@
-app_dir: /path/to/remote/app/directory
 project_name: 'projectname'
 project_description: 'Project Description'
 repository_url: YOUR_GIT_REPOSITORY_URL

--- a/boss/api/deployment/preset/remote_source.py
+++ b/boss/api/deployment/preset/remote_source.py
@@ -8,12 +8,13 @@ It then builds the project and restarts the service if needed.
 '''
 
 
-from fabric.api import task, hide
+from fabric.api import task, hide, cd
 from fabric.context_managers import shell_env
 
 from boss.config import get_stage_config
 from boss.util import remote_info, remote_print
 from boss.api import git, notif, shell, runner
+from boss.api.deployment.buildman import get_deploy_dir
 from boss.core.util.colors import cyan
 from boss.core.constants import known_scripts, notification_types
 
@@ -31,16 +32,18 @@ def deploy(branch=None):
         'commit': commit,
         'stage': stage
     })
-    runner.run_script_safely(known_scripts.PRE_DEPLOY)
 
-    # Get the latest code from the repository
-    sync(branch)
-    install_dependencies()
+    with cd(get_repo_path()):
+        runner.run_script_safely(known_scripts.PRE_DEPLOY)
 
-    # Building the app
-    build(stage)
-    reload_service()
-    runner.run_script_safely(known_scripts.POST_DEPLOY)
+        # Get the latest code from the repository
+        sync(branch)
+        install_dependencies()
+
+        # Building the app
+        build(stage)
+        reload_service()
+        runner.run_script_safely(known_scripts.POST_DEPLOY)
 
     notif.send(notification_types.DEPLOYMENT_FINISHED, {
         'user': deployer_user,
@@ -50,6 +53,11 @@ def deploy(branch=None):
     })
 
     remote_info('Deployment Completed')
+
+
+def get_repo_path():
+    ''' Get remote repository path. '''
+    return get_deploy_dir()
 
 
 def reload_service():
@@ -65,7 +73,6 @@ def install_dependencies():
     runner.run_script_safely(known_scripts.POST_INSTALL)
 
 
-@task
 def sync(branch=None):
     ''' Sync the changes on the branch with the remote (origin). '''
     remote_info('Fetching the latest changes.')
@@ -77,7 +84,6 @@ def sync(branch=None):
     git.sync(branch)
 
 
-@task
 def build(stage_name=None):
     ''' Build the application. '''
     stage = shell.get_stage()
@@ -92,30 +98,34 @@ def build(stage_name=None):
 @task
 def stop():
     ''' Stop the service. '''
-    runner.run_script_safely(known_scripts.STOP)
+    with cd(get_repo_path()):
+        runner.run_script_safely(known_scripts.STOP)
 
 
 @task
 def restart():
     ''' Restart the service. '''
-    runner.run_script_safely(known_scripts.RELOAD)
+    with cd(get_repo_path()):
+        runner.run_script_safely(known_scripts.RELOAD)
 
 
 @task
 def status():
     ''' Check the status of the service. '''
-    runner.run_script_safely(known_scripts.STATUS_CHECK)
+    with cd(get_repo_path()):
+        runner.run_script_safely(known_scripts.STATUS_CHECK)
 
 
 @task
 def check():
     ''' Check the current remote branch and the last commit. '''
-    with hide('running'):
-        # Show the current branch
-        remote_branch = git.current_branch()
-        remote_print('Branch: {}'.format(remote_branch))
-        # Show the last commit
-        git.show_last_commit()
+    with cd(get_repo_path()):
+        with hide('running'):
+            # Show the current branch
+            remote_branch = git.current_branch()
+            remote_print('Branch: {}'.format(remote_branch))
+            # Show the last commit
+            git.show_last_commit()
 
 
 def resolve_deployment_branch(stage):

--- a/boss/config.py
+++ b/boss/config.py
@@ -128,7 +128,7 @@ def get_base_config(resolved_config=None):
         'port': config.get('port'),
         'vault': config.get('vault'),
         'branch': config.get('branch'),
-        'app_dir': config.get('app_dir'),
+        'cwd': config.get('cwd'),
         'deployment': config.get('deployment'),
         'repository_url': config.get('repository_url'),
         'remote_env_path': config.get('remote_env_path')

--- a/boss/core/constants/config.py
+++ b/boss/core/constants/config.py
@@ -10,7 +10,7 @@ DEFAULT_CONFIG = {
     'key_filename': '~/.ssh/id_rsa',
     'ssh_forward_agent': False,
     'verbose_logging': False,
-    'app_dir': '~/',
+    'cwd': '/home/app',
     'branch': 'master',
     'repository_url': '',
     'project_name': 'untitled',

--- a/boss/init.py
+++ b/boss/init.py
@@ -56,7 +56,7 @@ def configure_env():
     stage_config = get_stage_config(stage)
     env.user = stage_config.get('user') or config['user']
     env.port = stage_config.get('port') or config['port']
-    env.cwd = stage_config.get('app_dir') or config['app_dir']
+    env.cwd = stage_config.get('cwd') or config['cwd']
     env.key_filename = stage_config.get(
         'key_filename') or config['key_filename']
     env.hosts = [stage_config['host']]

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -121,14 +121,14 @@ The public url to access this website.
 public_url: http://dev.your-app.com
 ```
 
-##### `app_dir`
+##### `cwd`
 
 `string`
 
-The absolute path of the project root directory in the server.
+The absolute path of the current working directory on the remote host.
 
 ```yml
-app_dir: /path/to/your/app
+cwd: /path/to/your/app
 ```
 
 ##### `logging`
@@ -310,7 +310,6 @@ stages:
   dev:
     host: dev.your-app.com
     public_url: http://dev.your-app.com
-    app_dir: /path/to/your/app
     logging:
       files:
         - /path/to/error/log/file
@@ -318,7 +317,6 @@ stages:
   uat:
     host: uat.your-app.com
     public_url: http://uat.your-app.com
-    app_dir: /path/to/your/app
     logging:
       files:
         - /path/to/error/log/file
@@ -328,7 +326,6 @@ stages:
     port: ${PRODUCTION_SERVER_SSH_PORT}
     username: ${PRODUCTION_SERVER_USERNAME}
     public_url: http://your-app.com
-    app_dir: /path/to/your/app
     logging:
       files:
         - /path/to/error/log/file


### PR DESCRIPTION
## Improvements
- Use `deployment.base_dir` instead of `app_dir` to make deployment config consistent across all the presets. 
- Previously the `app_dir` was being used as a current working directory setter on the remote which was by default being used by the remote-source directory as the app root directory. Now, all the presets including `remote-source` uses the `deployment.base_dir` as the application base directory
- For a setting a default current directory for general remote execution a new config option `cwd` is introduced. But this will be overridden by `base_dir` in all the deployment workflows.  

## Breaking Changes
- Config option `app_dir` has been removed, `deployment.base_dir` is the only option now.
- The `build` and `sync` aren't exposed as cli executable commands anymore.