### PR TITLE
Display specific vault error messages if boss halts due vault error

### DIFF
--- a/boss/config.py
+++ b/boss/config.py
@@ -116,7 +116,7 @@ def load(filename=DEFAULT_CONFIG_FILE, stage=None):
         halt('Invalid configuration file "{}"'.format(filename))
 
     except IOError:
-        halt('Error loading config file "%s"' % filename)
+        halt('Error loading config file "{}"'.format(filename))
 
 
 def get_base_config(resolved_config=None):

--- a/boss/core/vault.py
+++ b/boss/core/vault.py
@@ -48,7 +48,9 @@ def read_secrets(path):
     except Forbidden:
         halt(
             'Permission denied. ' +
-            'Make sure the token is authorized to access the configured path on vault.'
+            'Make sure the token is authorized to access `{}` on vault.'.format(
+                path
+            )
         )
 
     except VaultError as e:


### PR DESCRIPTION
Right now if vault shows any kind of error it just displays `Error loading config file "boss.yml"` which is misleading. 

Resolves #149

