### PR TITLE
Resolve deprecation errors due to paramiko's cryptography dependency version and the cwd issue on run() function

### DIFF
--- a/boss/core/constants/config.py
+++ b/boss/core/constants/config.py
@@ -10,7 +10,7 @@ DEFAULT_CONFIG = {
     'key_filename': '~/.ssh/id_rsa',
     'ssh_forward_agent': False,
     'verbose_logging': False,
-    'cwd': '/home/app',
+    'cwd': None,
     'branch': 'master',
     'repository_url': '',
     'project_name': 'untitled',

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,8 @@ setup(
         'python-dotenv==0.6.5',
         'terminaltables==3.1.0',
         'click==6.7',
-        'hvac==0.6.4'
+        'hvac==0.6.4',
+        'cryptography==2.4.2'
     ],
     extras_require={
         'test': ['mock', 'coverage', 'pytest', 'pytest-cov', 'pylint', 'pytest-watch'],


### PR DESCRIPTION
- Use `cryptography==2.4.2` to resolve the deprecation errors for paramiko. Check this [issue](https://github.com/paramiko/paramiko/issues/1369) for details. 
- Set `cwd` on default config to `None` to resolve the issue of changing current working directory to `/home/app` for every `run` invokation.  