### PR TITLE
Config loading - Display specific error message instead of the same error every time on failure

### DIFF
--- a/boss/config.py
+++ b/boss/config.py
@@ -117,10 +117,11 @@ def load(filename=DEFAULT_CONFIG_FILE, stage=None):
         halt('Invalid configuration file "{}"'.format(filename))
 
     except IOError as err:
+        # TODO: Handle from logger util.
         if os.environ.get('DEBUG') == 'true':
-            logging.exception('IOError')
+            logging.exception(err)
 
-        halt('Error loading config file "{}"'.format(filename))
+        halt(err)
 
 
 def get_base_config(resolved_config=None):


### PR DESCRIPTION
### Description

Log an exception error instead of same custom error message

### Cases:

- `boss.yml` file not found.
```py
[Errno 2] No such file or directory: 'boss.yml'
```

- Invalid vault address is set.
```py
Invalid URL 'test/v1/app/dev': No schema supplied. Perhaps you meant http://test/v1/app/dev?
```

### Enable `DEBUG` flag
```sh
$ DEBUG=true fab dev build
```

```py
Traceback (most recent call last):
  File "/Users/cham11ng/Source/boss/venv/lib/python2.7/site-packages/boss/config.py", line 104, in load
    use_vault_if_enabled(config_str, stage)
  File "/Users/cham11ng/Source/boss/venv/lib/python2.7/site-packages/boss/config.py", line 171, in use_vault_if_enabled
    vault.env_inject_secrets(path, silent=raw_config['vault']['silent'])
  File "/Users/cham11ng/Source/boss/venv/lib/python2.7/site-packages/boss/core/vault.py", line 65, in env_inject_secrets
    secrets = read_secrets(path)
  File "/Users/cham11ng/Source/boss/venv/lib/python2.7/site-packages/boss/core/vault.py", line 35, in read_secrets
    result = client.read(path)
  File "/Users/cham11ng/Source/boss/venv/lib/python2.7/site-packages/hvac/v1/__init__.py", line 157, in read
    return self._adapter.get('/v1/{0}'.format(path), wrap_ttl=wrap_ttl).json()
  File "/Users/cham11ng/Source/boss/venv/lib/python2.7/site-packages/hvac/adapters.py", line 90, in get
    return self.request('get', url, **kwargs)
  File "/Users/cham11ng/Source/boss/venv/lib/python2.7/site-packages/hvac/adapters.py", line 219, in request
    allow_redirects=False, **_kwargs)
  File "/Users/cham11ng/Source/boss/venv/lib/python2.7/site-packages/requests/sessions.py", line 510, in request
    prep = self.prepare_request(req)
  File "/Users/cham11ng/Source/boss/venv/lib/python2.7/site-packages/requests/sessions.py", line 453, in prepare_request
    hooks=merge_hooks(request.hooks, self.hooks),
  File "/Users/cham11ng/Source/boss/venv/lib/python2.7/site-packages/requests/models.py", line 313, in prepare
    self.prepare_url(url, params)
  File "/Users/cham11ng/Source/boss/venv/lib/python2.7/site-packages/requests/models.py", line 387, in prepare_url
    raise MissingSchema(error)
MissingSchema: Invalid URL 'test/v1/app/dev': No schema supplied. Perhaps you meant http://test/v1/app/dev?
```

